### PR TITLE
catch exceptions in max score compute

### DIFF
--- a/froggy/utils.py
+++ b/froggy/utils.py
@@ -262,10 +262,7 @@ def cleanup_pytest_output(output):
 
 def extract_max_score_from_pytest_output(output):
     # ... collected 25 items
-    try:
-        return int(re.search(r"collected (\d+) items", output).group(1))
-    except:
-        return 1
+    return int(re.search(r"collected (\d+) items?", output).group(1))
 
 
 def extract_reward_from_pytest_output(output):


### PR DESCRIPTION
For cases where `re.search(r"collected (\d+) items", output)` is None.