### PR TITLE
Use logging instead of print. Add nice progress visualization.

### DIFF
--- a/froggy/agents/base.py
+++ b/froggy/agents/base.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import subprocess
 import uuid
@@ -10,6 +9,7 @@ import numpy as np
 from froggy.agents.llm_api import instantiate_llm
 from froggy.agents.utils import HistoryTracker, build_history_prompt
 from froggy.envs.env import RepoEnv
+from froggy.logger import FroggyLogger
 from froggy.utils import unescape
 
 
@@ -20,11 +20,11 @@ class AgentBase:
         self,
         config: dict,
         env: RepoEnv,
-        logger: logging.Logger | None = None,
+        logger: FroggyLogger | None = None,
     ):
         self.config = config
         self.env = env
-        self.logger = logger or logging.getLogger("froggy")
+        self.logger = logger or FroggyLogger("froggy")
         self.llm = instantiate_llm(self.config, logger=self.logger)
         self._uuid = self.config.get("uuid", str(uuid.uuid4()))
         self._output_path = pjoin(self.config["output_path"], self._uuid)

--- a/froggy/agents/cot.py
+++ b/froggy/agents/cot.py
@@ -14,9 +14,6 @@ from froggy.utils import unescape
 class AgentCoT(AgentBase):
     name: str = "cot"
 
-    def __init__(self, config_dict, env, verbose=False, _uuid=None):
-        super().__init__(config_dict, env, verbose, _uuid)
-
     def build_cot_prompt(self):
         messages = []
         cot_prompt = [
@@ -134,10 +131,6 @@ class AgentCoT(AgentBase):
 
 class AgentCoT_NoPDB(AgentCoT):
     name: str = "cot no pdb"
-
-    def __init__(self, config_dict, env, verbose=False, _uuid=None):
-        super().__init__(config_dict, env, verbose, _uuid)
-        self.history = HistoryTracker(self.config["memory_size"])
 
     def build_system_prompt(self, info):
         system_prompt = {}

--- a/froggy/agents/cot.py
+++ b/froggy/agents/cot.py
@@ -1,7 +1,5 @@
 import json
 
-from tqdm import tqdm
-
 from froggy.agents import AgentBase
 from froggy.agents.utils import (
     HistoryTracker,
@@ -80,14 +78,9 @@ class AgentCoT(AgentBase):
 
         done = False
         highscore = info["score"]
-        pbar = tqdm(
-            total=self.config["max_steps"],
-            desc=f"Debugging inside {self.env.working_dir}",
-            leave=True,
-        )
-        for step in range(self.config["max_steps"]):
+        for step in self.logger.tqdm(range(self.config["max_steps"])):
             highscore = max(highscore, info["score"])
-            pbar.set_postfix_str(
+            self.logger.debug(
                 f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
                     info["score"]
                 )
@@ -118,9 +111,8 @@ class AgentCoT(AgentBase):
                 prompt_response_pairs=prompt_response_pairs
             )
 
-            pbar.update()
             if done or info["rewrite_counter"] >= self.config["max_rewrite_steps"]:
-                pbar.set_postfix_str(
+                self.logger.info(
                     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
                         info["score"]
                     )

--- a/froggy/agents/llm_api.py
+++ b/froggy/agents/llm_api.py
@@ -31,39 +31,25 @@ except ImportError:
 
 logger = logging.getLogger("froggy")
 
-LLM_CONFIG_FILE = os.environ.get("LLM_CONFIG_FILE", "llm.cfg")
+
+def load_llm_config(config_file_path: str | None = None):
+    if config_file_path is None:
+        config_file_path = os.environ.get("LLM_CONFIG_FILE", "llm.cfg")
+    try:
+        llm_config = json.load(open(config_file_path))
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Cannot find llm config file: {config_file_path}")
+    return llm_config
 
 
-def is_rate_limit_error(exception):
-    # List of fully qualified names of RateLimitError exceptions from various libraries
-    rate_limit_errors = [
-        "openai.APIStatusError",
-        "openai.APITimeoutError",
-        "openai.error.Timeout",
-        "openai.error.RateLimitError",
-        "openai.error.ServiceUnavailableError",
-        "openai.Timeout",
-        "openai.APIError",
-        "openai.APIConnectionError",
-        "openai.RateLimitError",
-        # Add more as needed
-    ]
-    exception_full_name = (
-        f"{exception.__class__.__module__}.{exception.__class__.__name__}"
-    )
-    logger.warning(f"Exception_full_name: {exception_full_name}")
-    logger.warning(f"Exception: {exception}")
-    return exception_full_name in rate_limit_errors
-
-
-def print_messages(messages):
+def print_messages(messages: list[dict], logger: logging.Logger):
     for m in messages:
         if m["role"] == "user":
-            print(colored(f"{m['content']}\n", "cyan"))
+            logger.debug(colored(f"{m['content']}\n", "cyan"))
         elif m["role"] == "assistant":
-            print(colored(f"{m['content']}\n", "green"))
+            logger.debug(colored(f"{m['content']}\n", "green"))
         elif m["role"] == "system":
-            print(colored(f"{m['content']}\n", "yellow"))
+            logger.debug(colored(f"{m['content']}\n", "yellow"))
         else:
             raise ValueError(f"Unknown role: {m['content']}")
 
@@ -108,30 +94,18 @@ class TokenCounter:
 
 
 class LLM:
-    def __init__(self, model_name, verbose=False):
-        if os.path.exists(LLM_CONFIG_FILE):
-            configs = json.load(open(LLM_CONFIG_FILE))
-            if model_name not in configs:
-                raise ValueError(f"Model {self.model_name} not found in llm.cfg")
-        else:
-            raise ValueError(f"Cannot find {LLM_CONFIG_FILE}.")
+    def __init__(self, model_name: str, logger: logging.Logger | None = None):
+        configs = load_llm_config()
+        if model_name not in configs:
+            raise ValueError(f"Model {model_name} not found in llm.cfg")
 
         self.model_name = model_name
         self.config = configs[model_name]
-        self.verbose = verbose
-
-        if os.path.exists(LLM_CONFIG_FILE):
-            LLM_CONFIGS = json.load(open(LLM_CONFIG_FILE))
-            available_models = list(LLM_CONFIGS.keys()) + ["random", "human"]
-
-        if self.model_name not in LLM_CONFIGS:
-            raise Exception(f"Model {self.model_name} not found in llm.cfg")
-
-        self.config = LLM_CONFIGS[self.model_name]
+        self.logger = logger or logging.getLogger("froggy")
         self.token_counter = TokenCounter(self.config["tokenizer"])
         self.context_length = self.config["context_limit"] * 1000
 
-        logger.debug(
+        self.logger.debug(
             f"Using {self.model_name} with max context length of {
                 self.context_length:,} tokens."
         )
@@ -146,6 +120,12 @@ class LLM:
                 base_url=self.config["endpoint"],
                 timeout=None,
             )
+
+        self.call_with_retry = retry(
+            retry=retry_if_exception(self.is_rate_limit_error),
+            wait=wait_random_exponential(multiplier=1, max=40),
+            stop=stop_after_attempt(100),
+        )
 
     def _get_azure_oai_kwargs(self):
         """
@@ -174,23 +154,36 @@ class LLM:
             )
         return kwargs
 
-    @retry(
-        retry=retry_if_exception(is_rate_limit_error),
-        wait=wait_random_exponential(multiplier=1, max=40),
-        stop=stop_after_attempt(100),
-    )
+    def is_rate_limit_error(self, exception):
+        # List of fully qualified names of RateLimitError exceptions from various libraries
+        rate_limit_errors = [
+            "openai.APIStatusError",
+            "openai.APITimeoutError",
+            "openai.error.Timeout",
+            "openai.error.RateLimitError",
+            "openai.error.ServiceUnavailableError",
+            "openai.Timeout",
+            "openai.APIError",
+            "openai.APIConnectionError",
+            "openai.RateLimitError",
+            # Add more as needed
+        ]
+        exception_full_name = (
+            f"{exception.__class__.__module__}.{exception.__class__.__name__}"
+        )
+        self.logger.warning(f"Error calling {self.model_name}: {exception_full_name!r}")
+        self.logger.debug(f"Exception: {exception.message}")
+        return exception_full_name in rate_limit_errors
+
     def query_model(self, messages, **kwargs):
         kwargs["max_tokens"] = kwargs.get("max_tokens", self.config.get("max_tokens"))
 
-        return (
-            self.client.chat.completions.create(
-                model=self.config["model"],
-                messages=messages,
-                **kwargs,
-            )
-            .choices[0]
-            .message.content
+        reponse = self.call_with_retry(self.client.chat.completions.create)(
+            model=self.config["model"],
+            messages=messages,
+            **kwargs,
         )
+        return reponse.choices[0].message.content
 
     def __call__(self, messages, *args, **kwargs):
         if not self.config.get("system_prompt_support", True):
@@ -205,16 +198,14 @@ class LLM:
             messages, self.context_length, self.token_counter
         )
 
-        if self.verbose:
-            # Message is a list of dictionaries with role and content keys.
-            # Color each role differently.
-            print_messages(messages)
+        # Message is a list of dictionaries with role and content keys.
+        # Color each role differently.
+        print_messages(messages, self.logger)
 
         response = self.query_model(messages, **kwargs)
         response = response.strip()
 
-        if self.verbose:
-            print(colored(response, "green"))
+        self.logger.debug(colored(response, "green"))
 
         token_usage = {
             "prompt": self.token_counter(messages=messages),
@@ -225,8 +216,8 @@ class LLM:
 
 
 class AsyncLLM(LLM):
-    def __init__(self, model_name, verbose=False):
-        super().__init__(model_name, verbose)
+    def __init__(self, model_name, logger: logging.Logger | None = None):
+        super().__init__(model_name, logger)
 
         if "azure openai" in self.config.get("tags", []):
             kwargs = self._get_azure_oai_kwargs()
@@ -238,25 +229,15 @@ class AsyncLLM(LLM):
                 timeout=None,
             )
 
-    @retry(
-        retry=retry_if_exception(is_rate_limit_error),
-        wait=wait_random_exponential(multiplier=1, max=40),
-        stop=stop_after_attempt(100),
-    )
     async def query_model(self, messages, **kwargs):
         kwargs["max_tokens"] = kwargs.get("max_tokens", self.config.get("max_tokens"))
 
-        return (
-            (
-                await self.client.chat.completions.create(
-                    model=self.config["model"],
-                    messages=messages,
-                    **kwargs,
-                )
-            )
-            .choices[0]
-            .message.content
+        response = await self.call_with_retry(self.client.chat.completions.create)(
+            model=self.config["model"],
+            messages=messages,
+            **kwargs,
         )
+        return response.choices[0].message.content
 
     async def __call__(self, messages, *args, **kwargs):
         if not self.config.get("system_prompt_support", True):
@@ -277,14 +258,15 @@ class AsyncLLM(LLM):
 
 
 class Human:
-    def __init__(self):
+    def __init__(self, logger: logging.Logger | None = None):
         self._history = None
+        self.logger = logger or logging.getLogger("froggy")
         if prompt_toolkit_available:
             self._history = InMemoryHistory()
 
     def __call__(self, messages, info, *args, **kwargs):
         # Color each role differently.
-        print_messages(messages)
+        print_messages(messages, self.logger)
         available_commands = info.get("available_commands", [])
 
         if prompt_toolkit_available:
@@ -312,19 +294,16 @@ class Human:
 
 
 class Random:
-    def __init__(self, seed, verbose=False):
+    def __init__(self, seed: int, logger: logging.Logger | None = None):
         self.seed = seed
-        self.verbose = verbose
+        self.logger = logger or logging.getLogger("froggy")
         self.rng = random.Random(seed)
 
     def __call__(self, messages, info, *args, **kwargs):
-        if self.verbose:
-            print_messages(messages)
+        print_messages(messages, self.logger)
 
         action = self.rng.choice(info.get("available_commands", ["noop"]))
-
-        if self.verbose:
-            print(colored(action, "green"))
+        self.logger.debug(colored(action, "green"))
 
         token_usage = {
             "prompt": len("\n".join([msg["content"] for msg in messages])),
@@ -334,21 +313,23 @@ class Random:
         return action, token_usage
 
 
-def instantiate_llm(config, verbose=False, use_async=False):
-    if os.path.exists(LLM_CONFIG_FILE):
-        LLM_CONFIGS = json.load(open(LLM_CONFIG_FILE))
-        available_models = list(LLM_CONFIGS.keys()) + ["random", "human"]
-    assert (
-        config["llm_name"] in available_models
-    ), f"Model {config['llm_name']} is not available, please make sure the LLM config file is correctly set."
-
+def instantiate_llm(
+    config: dict, logger: logging.Logger | None = None, use_async: bool = False
+):
+    llm_config = load_llm_config()
+    available_models = list(llm_config.keys()) + ["random", "human"]
+    if config["llm_name"] not in available_models:
+        raise ValueError(
+            f"Model {config['llm_name']} is not available, "
+            "please make sure the LLM config file is correctly set."
+        )
     if config["llm_name"] == "random":
-        llm = Random(config["random_seed"], verbose)
+        llm = Random(config["random_seed"], logger=logger)
     elif config["llm_name"] == "human":
-        llm = Human()
+        llm = Human(logger=logger)
     else:
         if use_async:
-            llm = AsyncLLM(config["llm_name"], verbose=verbose)
+            llm = AsyncLLM(config["llm_name"], logger=logger)
         else:
-            llm = LLM(config["llm_name"], verbose=verbose)
+            llm = LLM(config["llm_name"], logger=logger)
     return llm

--- a/froggy/agents/tadpole.py
+++ b/froggy/agents/tadpole.py
@@ -1,7 +1,3 @@
-import json
-
-from tqdm import tqdm
-
 from froggy.agents import AgentBase
 
 
@@ -119,14 +115,10 @@ class AgentTadpole(AgentBase):
 
         done = False
         highscore = info["score"]
-        pbar = tqdm(
-            total=self.config["max_steps"],
-            desc=f"Debugging inside {self.env.working_dir}",
-            leave=True,
-        )
-        for step in range(self.config["max_steps"]):
+
+        for step in self.logger.tqdm(range(self.config["max_steps"])):
             highscore = max(highscore, info["score"])
-            pbar.set_postfix_str(
+            self.logger.info(
                 f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
                     info["score"]
                 )
@@ -172,9 +164,8 @@ class AgentTadpole(AgentBase):
                 prompt_response_pairs=prompt_response_pairs
             )
 
-            pbar.update()
             if done or info["rewrite_counter"] >= self.config["max_rewrite_steps"]:
-                pbar.set_postfix_str(
+                self.logger.info(
                     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
                         info["score"]
                     )

--- a/froggy/agents/tadpole.py
+++ b/froggy/agents/tadpole.py
@@ -15,8 +15,8 @@ class AgentTadpole(AgentBase):
 
     name: str = "tadpole"
 
-    def __init__(self, config_dict, env, verbose=False, _uuid=None):
-        super().__init__(config_dict, env, verbose, _uuid)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.current_subgoal = None
 
     def build_task_decomposer_prompt(self):

--- a/froggy/agents/zero_shot.py
+++ b/froggy/agents/zero_shot.py
@@ -9,9 +9,6 @@ from froggy.utils import unescape
 class AgentZeroShot(AgentBase):
     name: str = "zero shot"
 
-    def __init__(self, config_dict, env, verbose=False, _uuid=None):
-        super().__init__(config_dict, env, verbose, _uuid)
-
     def build_question_prompt(self):
         messages = []
         question = "Based on the instruction, the current code, the last execution output, and the history information, "
@@ -38,14 +35,20 @@ class AgentZeroShot(AgentBase):
         done = False
         highscore = info["score"]
 
-        pbar = tqdm(
-            total=self.config["max_steps"],
-            desc=f"Debugging inside {self.env.working_dir} - Task: {task_name}",
-            leave=True,
-        )
+        # pbar = tqdm(
+        #     total=self.config["max_steps"],
+        #     desc=f"Debugging inside {self.env.working_dir} - Task: {task_name}",
+        #     leave=True,
+        # )
+        self.logger.progress.update(self.logger.task_id, total=self.config["max_steps"])
         for step in range(self.config["max_steps"]):
             highscore = max(highscore, info["score"])
-            pbar.set_postfix_str(
+            # pbar.set_postfix_str(
+            #     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
+            #         info["score"]
+            #     )
+            # )
+            self.logger.info(
                 f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
                     info["score"]
                 )
@@ -68,9 +71,15 @@ class AgentZeroShot(AgentBase):
                 prompt_response_pairs=[(prompt, answer)]
             )
 
-            pbar.update()
+            # pbar.update()
+            self.logger.progress.update(self.logger.task_id, advance=1)
             if done or info["rewrite_counter"] >= self.config["max_rewrite_steps"]:
-                pbar.set_postfix_str(
+                # pbar.set_postfix_str(
+                #     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
+                #         info["score"]
+                #     )
+                # )
+                self.logger.info(
                     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
                         info["score"]
                     )
@@ -81,9 +90,6 @@ class AgentZeroShot(AgentBase):
 
 class AgentZeroShot_NoPDB(AgentZeroShot):
     name: str = "zero shot no pdb"
-
-    def __init__(self, config_dict, env, verbose=False, _uuid=None):
-        super().__init__(config_dict, env, verbose, _uuid)
 
     def build_system_prompt(self, info):
         system_prompt = {}
@@ -118,9 +124,6 @@ class AgentZeroShot_NoPDB(AgentZeroShot):
 
 class AgentZeroShot_PdbAfterRewrites(AgentZeroShot):
     name: str = "zero shot pdb after rewrites"
-
-    def __init__(self, config_dict, env, verbose=False, _uuid=None):
-        super().__init__(config_dict, env, verbose, _uuid)
 
     def run(self, task_name=None, debug=False):
         # remove the pdb tool from the environment

--- a/froggy/agents/zero_shot.py
+++ b/froggy/agents/zero_shot.py
@@ -1,7 +1,5 @@
 import json
 
-from tqdm import tqdm
-
 from froggy.agents import AgentBase
 from froggy.utils import unescape
 
@@ -35,19 +33,8 @@ class AgentZeroShot(AgentBase):
         done = False
         highscore = info["score"]
 
-        # pbar = tqdm(
-        #     total=self.config["max_steps"],
-        #     desc=f"Debugging inside {self.env.working_dir} - Task: {task_name}",
-        #     leave=True,
-        # )
-        self.logger.progress.update(self.logger.task_id, total=self.config["max_steps"])
-        for step in range(self.config["max_steps"]):
+        for step in self.logger.tqdm(range(self.config["max_steps"])):
             highscore = max(highscore, info["score"])
-            # pbar.set_postfix_str(
-            #     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
-            #         info["score"]
-            #     )
-            # )
             self.logger.info(
                 f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
                     info["score"]
@@ -71,14 +58,7 @@ class AgentZeroShot(AgentBase):
                 prompt_response_pairs=[(prompt, answer)]
             )
 
-            # pbar.update()
-            self.logger.progress.update(self.logger.task_id, advance=1)
             if done or info["rewrite_counter"] >= self.config["max_rewrite_steps"]:
-                # pbar.set_postfix_str(
-                #     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
-                #         info["score"]
-                #     )
-                # )
                 self.logger.info(
                     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
                         info["score"]
@@ -140,14 +120,10 @@ class AgentZeroShot_PdbAfterRewrites(AgentZeroShot):
 
         done = False
         highscore = info["score"]
-        pbar = tqdm(
-            total=self.config["max_steps"],
-            desc=f"Debugging inside {self.env.working_dir}",
-            leave=True,
-        )
-        for step in range(self.config["max_steps"]):
+
+        for step in self.logger.tqdm(range(self.config["max_steps"])):
             highscore = max(highscore, info["score"])
-            pbar.set_postfix_str(
+            self.logger.info(
                 f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%}) [Best: {highscore}]".format(
                     info["score"]
                 )
@@ -181,9 +157,8 @@ class AgentZeroShot_PdbAfterRewrites(AgentZeroShot):
                 prompt_response_pairs=[(prompt, answer)]
             )
 
-            pbar.update()
             if done or info["rewrite_counter"] >= self.config["max_rewrite_steps"]:
-                pbar.set_postfix_str(
+                self.logger.info(
                     f"Score: {info['score']}/{info['max_score']} ({info['score']/info['max_score']:.1%})".format(
                         info["score"]
                     )

--- a/froggy/envs/env.py
+++ b/froggy/envs/env.py
@@ -1,6 +1,5 @@
 import atexit
 import glob
-import logging
 import os
 import shutil
 import subprocess
@@ -8,11 +7,10 @@ import tempfile
 from glob import glob
 from os.path import join as pjoin
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
-from termcolor import colored
 
+from froggy.logger import FroggyLogger
 from froggy.terminal import Terminal
 from froggy.tools.patchers import CodePatcher
 from froggy.tools.pdb import PDBTool
@@ -69,7 +67,7 @@ class RepoEnv(TooledEnv):
         dir_tree_depth: int | None = None,
         auto_view_change: bool = True,
         terminal: Terminal | None = None,
-        logger=logging.getLogger("froggy"),
+        logger: FroggyLogger | None = None,
     ):
         super().__init__()
 
@@ -81,7 +79,7 @@ class RepoEnv(TooledEnv):
         self.auto_view_change = auto_view_change
         self.terminal = terminal or Terminal()
         self.entrypoint = entrypoint
-        self.logger = logger
+        self.logger = logger or FroggyLogger("froggy")
 
         self.setup_workspace(path, readonly_patterns=readonly_patterns)
         self.last_run_obs = None

--- a/froggy/envs/env.py
+++ b/froggy/envs/env.py
@@ -18,8 +18,6 @@ from froggy.tools.patchers import CodePatcher
 from froggy.tools.pdb import PDBTool
 from froggy.utils import _walk, make_is_readonly, show_line_number
 
-logger = logging.getLogger("froggy")
-
 
 class TooledEnv:
     def __init__(self):
@@ -71,6 +69,7 @@ class RepoEnv(TooledEnv):
         dir_tree_depth: int | None = None,
         auto_view_change: bool = True,
         terminal: Terminal | None = None,
+        logger=logging.getLogger("froggy"),
     ):
         super().__init__()
 
@@ -82,6 +81,7 @@ class RepoEnv(TooledEnv):
         self.auto_view_change = auto_view_change
         self.terminal = terminal or Terminal()
         self.entrypoint = entrypoint
+        self.logger = logger
 
         self.setup_workspace(path, readonly_patterns=readonly_patterns)
         self.last_run_obs = None
@@ -111,7 +111,7 @@ class RepoEnv(TooledEnv):
             self.tempdir.cleanup
         )  # Make sure to cleanup that folder once done.
 
-        logger.debug(f"Working directory: {self.working_dir}")
+        self.logger.debug(f"Working directory: {self.working_dir}")
         shutil.copytree(self.path, self.working_dir, dirs_exist_ok=True)
 
         # get list of all the files
@@ -179,6 +179,7 @@ class RepoEnv(TooledEnv):
             shutil.copy2(self.path / filepath, self.working_dir / filepath)
 
     def reset(self, *, seed=None, options: dict = None):
+        self.logger.info(f"Resetting environment")
         options = options or {}
         self.current_file = None
         self.current_file_content = None
@@ -187,6 +188,7 @@ class RepoEnv(TooledEnv):
         self.restore()
 
         # Run the initial code. This will set self.last_run_obs, self.done and self.score.
+        self.logger.info(f"Running initial evaluation")
         self.run()
 
         self.obs = ""

--- a/froggy/logger.py
+++ b/froggy/logger.py
@@ -52,7 +52,7 @@ class FroggyLogger(logging.Logger):
         self,
         name: str,
         log_dir: str | None = None,
-        verbose: bool = False,
+        level: str | int = logging.INFO,
         mode: str = "a",
     ):
         super().__init__(name)
@@ -62,7 +62,7 @@ class FroggyLogger(logging.Logger):
         )
 
         ph = ProgressHandler(self.task_progress, self.task_id)
-        ph.setLevel(logging.DEBUG if verbose else logging.INFO)
+        ph.setLevel(level)
         formatter = logging.Formatter("%(levelname)-8s %(message)s")
         ph.setFormatter(formatter)
         self.addHandler(ph)
@@ -70,7 +70,7 @@ class FroggyLogger(logging.Logger):
         console = logging.StreamHandler()
         formatter = logging.Formatter("🐸 [%(name)-12s]: %(levelname)-8s %(message)s")
         console.setFormatter(formatter)
-        console.setLevel(logging.DEBUG if verbose else logging.INFO)
+        console.setLevel(level)
         self.addHandler(console)
 
         if log_dir:

--- a/froggy/logger.py
+++ b/froggy/logger.py
@@ -1,0 +1,102 @@
+import logging
+import re
+from pathlib import Path
+
+from rich.console import Group
+from rich.live import Live
+from rich.logging import RichHandler
+from rich.panel import Panel
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+from rich.table import Column
+
+
+class ProgressHandler(RichHandler):
+    def __init__(self, progress, task_id, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.task_id = task_id
+        self.progress = progress
+
+    def emit(self, record):
+        if self.task_id not in self.progress.task_ids:
+            return
+
+        # Strip color codes from the log message
+        message = re.sub(r"\x1b\[[0-9;]*m", "", self.format(record))
+        message = message.replace("\n", "\\n").replace("\r", "\\r")
+        # Truncate message to 80 characters
+        message = message[:80] + "..." if len(message) > 80 else message
+        self.progress.update(self.task_id, log=message)
+
+
+class FroggyLogger(logging.Logger):
+    task_progress = Progress(
+        TimeElapsedColumn(),
+        BarColumn(bar_width=10),
+        TextColumn("{task.description}"),
+        TextColumn(
+            "{task.fields[log]}", table_column=Column(no_wrap=True)  # , width=80)
+        ),
+    )
+    overall_progress = Progress(
+        TextColumn("🐸"),
+        TimeElapsedColumn(),
+        BarColumn(),
+        TextColumn("{task.description}"),
+    )
+    progress_group = Group(
+        Panel(task_progress, title="Workers"),
+        overall_progress,
+    )
+
+    def __init__(
+        self,
+        name: str,
+        log_dir: str | None = None,
+        verbose: bool = False,
+        mode: str = "a",
+    ):
+        super().__init__(name)
+        self.setLevel(logging.DEBUG)
+        self.task_id = self.task_progress.add_task(
+            f"\\[{name}]:", log="Starting task..."
+        )
+
+        ph = ProgressHandler(self.task_progress, self.task_id)
+        ph.setLevel(logging.DEBUG if verbose else logging.INFO)
+        formatter = logging.Formatter("%(levelname)-8s %(message)s")
+        ph.setFormatter(formatter)
+        self.addHandler(ph)
+
+        console = logging.StreamHandler()
+        formatter = logging.Formatter("🐸 [%(name)-12s]: %(levelname)-8s %(message)s")
+        console.setFormatter(formatter)
+        console.setLevel(logging.DEBUG if verbose else logging.INFO)
+        self.addHandler(console)
+
+        if log_dir:
+            log_dir = Path(log_dir)
+            log_dir.mkdir(parents=True, exist_ok=True)
+
+            self.log_file = log_dir / f"{name}.log"
+            fh = logging.FileHandler(self.log_file, mode=mode)
+            formatter = logging.Formatter("%(asctime)s %(levelname)-8s %(message)s")
+            fh.setFormatter(formatter)
+            fh.setLevel(logging.DEBUG)
+            self.addHandler(fh)
+
+        # Prevent the log messages from being propagated to the root logger
+        self.propagate = False
+
+    def tqdm(self, iterable, total=None, desc=None, unit="it", ncols=80):
+        total = len(iterable) if total is None else total
+        desc = "" if desc is None else desc
+        unit = "" if unit is None else unit
+        self.task_progress.update(self.task_id, total=total)
+        for i, item in enumerate(iterable):
+            self.task_progress.update(self.task_id, advance=1)
+            yield item
+
+    def stop(self, remove: bool = False):
+        self.task_progress.stop(self.task_id)
+        if remove:
+            self.task_progress.remove_task(self.task_id)

--- a/froggy/terminal.py
+++ b/froggy/terminal.py
@@ -2,7 +2,6 @@ import atexit
 import errno
 import fcntl
 import io
-import logging
 import os
 import pty
 import shlex
@@ -13,6 +12,8 @@ import time
 
 import docker
 
+from froggy.logger import FroggyLogger
+
 
 class Terminal:
 
@@ -22,10 +23,10 @@ class Terminal:
         setup_commands: list[str] = None,
         env_vars: dict[str, str] = None,
         include_os_env_vars: bool = True,
-        logger: logging.Logger | None = None,
+        logger: FroggyLogger | None = None,
         **kwargs,
     ):
-        self.logger = logger or logging.getLogger("froggy")
+        self.logger = logger or FroggyLogger("froggy")
         self.setup_commands = setup_commands or []
         self.env_vars = env_vars or {}
         if include_os_env_vars:

--- a/froggy/tests/test_cot.py
+++ b/froggy/tests/test_cot.py
@@ -85,7 +85,6 @@ class TestAgentCoT(unittest.TestCase):
         messages = self.agent.build_prompt_step_2(info, response)
         self.assertGreater(len(messages), 0)
 
-    @patch("froggy.agents.cot.tqdm", MagicMock())
     def test_run(self):
         self.env.reset.return_value = (
             None,

--- a/froggy/tests/test_cot.py
+++ b/froggy/tests/test_cot.py
@@ -37,7 +37,7 @@ class TestAgentCoT(unittest.TestCase):
         self.env = MagicMock()
         self.llm = MagicMock()
         self.history = MagicMock()
-        self.agent = AgentCoT(self.config_dict, self.env, verbose=False)
+        self.agent = AgentCoT(self.config_dict, self.env)
         self.agent.llm = self.llm
         self.agent.history = self.history
 
@@ -148,7 +148,7 @@ class TestAgentCoT_NoPDB(unittest.TestCase):
         self.env = MagicMock()
         self.llm = MagicMock()
         self.history = MagicMock()
-        self.agent = AgentCoT_NoPDB(self.config_dict, self.env, verbose=False)
+        self.agent = AgentCoT_NoPDB(self.config_dict, self.env)
         self.agent.llm = self.llm
         self.agent.history = self.history
 

--- a/froggy/tests/test_llm_api.py
+++ b/froggy/tests/test_llm_api.py
@@ -12,16 +12,16 @@ from froggy.agents.llm_api import (
     Random,
     TokenCounter,
     instantiate_llm,
-    is_rate_limit_error,
     load_llm_config,
     merge_messages,
     print_messages,
 )
+from froggy.logger import FroggyLogger
 
 
 @pytest.fixture
 def logger_mock():
-    logger = logging.getLogger("test_logger")
+    logger = FroggyLogger("test_logger")
     logger.setLevel(logging.DEBUG)
     logs = []
 

--- a/froggy/tests/test_llm_api.py
+++ b/froggy/tests/test_llm_api.py
@@ -1,6 +1,5 @@
-import sys
-import unittest
-from io import StringIO
+import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -14,182 +13,197 @@ from froggy.agents.llm_api import (
     TokenCounter,
     instantiate_llm,
     is_rate_limit_error,
+    load_llm_config,
     merge_messages,
     print_messages,
 )
 
 
-class TestLLMAPI(unittest.TestCase):
+@pytest.fixture
+def logger_mock():
+    logger = logging.getLogger("test_logger")
+    logger.setLevel(logging.DEBUG)
+    logs = []
 
-    @pytest.fixture
-    def async_llm(self):
-        # Create an instance of AsyncLLM with a mock configuration
-        model_name = "test-model"
-        verbose = False
-        async_llm = AsyncLLM(model_name, verbose)
-        return async_llm
+    class ListHandler(logging.Handler):
+        def emit(self, record):
+            logs.append(record.getMessage())
 
-    def test_is_rate_limit_error(self):
-        mock_response = MagicMock()
-        mock_response.request = "example"
-        mock_response.body = {"error": "Rate limit exceeded"}
-        # Instantiate the RateLimitError with the mock response
-        exception = RateLimitError(
-            "Rate limit exceeded", response=mock_response, body=mock_response.body
+    handler = ListHandler()
+    logger.addHandler(handler)
+    logger._log_history = logs
+    return logger
+
+
+@pytest.fixture
+def async_llm(logger_mock):
+    # Create an instance of AsyncLLM with a mock configuration
+    model_name = "test-model"
+    async_llm = AsyncLLM(model_name, logger=logger_mock)
+    return async_llm
+
+
+def test_is_rate_limit_error():
+    mock_response = MagicMock()
+    mock_response.request = "example"
+    mock_response.body = {"error": "Rate limit exceeded"}
+    # Instantiate the RateLimitError with the mock response
+    exception = RateLimitError(
+        "Rate limit exceeded", response=mock_response, body=mock_response.body
+    )
+    assert is_rate_limit_error(exception) == True
+
+
+def test_print_messages(logger_mock):
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+        {"role": "system", "content": "System message"},
+    ]
+    print_messages(messages, logger_mock)
+    assert logger_mock._log_history == ["Hello\n", "Hi\n", "System message\n"]
+
+
+def test_merge_messages():
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "user", "content": "How are you?"},
+        {"role": "assistant", "content": "Hi"},
+    ]
+    merged = merge_messages(messages)
+    assert len(merged) == 2
+    assert merged[0]["content"] == "Hello\n\nHow are you?"
+
+
+@patch("tiktoken.encoding_for_model")
+def test_token_counter(mock_encoding_for_model):
+    mock_encoding = MagicMock()
+    mock_encoding.encode = lambda x: x.split()
+    mock_encoding_for_model.return_value = mock_encoding
+
+    counter = TokenCounter(model="gpt-4o")
+    messages = [{"content": "Hello"}, {"content": "How are you?"}]
+    assert counter(messages=messages) > 0
+    assert counter(text="Hello") > 0
+
+
+@patch("tiktoken.encoding_for_model")
+@patch("openai.resources.chat.completions.Completions.create")
+@patch("os.path.exists", return_value=True)
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data='{"test-model": {"model": "test-model", "max_tokens": 100, "tokenizer": "gpt-4o", "context_limit": 4, "api_key": "test-api-key", "endpoint": "https://test-endpoint", "api_version": "v1", "tags": ["azure openai"]}}',
+)
+def test_llm(mock_open, mock_exists, mock_openai, mock_encoding_for_model, logger_mock):
+    mock_encoding = MagicMock()
+    mock_encoding.encode = lambda x: x.split()
+    mock_encoding_for_model.return_value = mock_encoding
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Response"
+    mock_openai.return_value = mock_response
+
+    llm = LLM(model_name="test-model", logger=logger_mock)
+    messages = [{"role": "user", "content": "Hello"}]
+    response, token_usage = llm(messages)
+    assert response == "Response"
+    assert "prompt" in token_usage
+    assert "response" in token_usage
+
+
+@pytest.fixture
+def llm_config_mock(tmp_path, monkeypatch):
+    config_file = tmp_path / "llm.cfg"
+    config_file.write_text(
+        json.dumps(
+            {
+                "test_model": {
+                    "model": "test_model",
+                    "tokenizer": "gpt-4o",
+                    "endpoint": "https://test_endpoint",
+                    "api_key": "test_api",
+                    "api_version": "1.0",
+                    "context_limit": 128,
+                    "tags": ["azure openai"],
+                }
+            }
         )
-        assert is_rate_limit_error(exception) == True
-
-    def test_print_messages(self):
-        messages = [
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi"},
-            {"role": "system", "content": "System message"},
-        ]
-        captured_output = StringIO()
-        sys.stdout = captured_output
-        print_messages(messages)
-        sys.stdout = sys.__stdout__
-        captured = captured_output.getvalue()
-        assert "Hello" in captured
-        assert "Hi" in captured
-        assert "System message" in captured
-
-    def test_merge_messages(self):
-        messages = [
-            {"role": "user", "content": "Hello"},
-            {"role": "user", "content": "How are you?"},
-            {"role": "assistant", "content": "Hi"},
-        ]
-        merged = merge_messages(messages)
-        assert len(merged) == 2
-        assert merged[0]["content"] == "Hello\n\nHow are you?"
-
-    @patch("tiktoken.encoding_for_model")
-    def test_token_counter(self, mock_encoding_for_model):
-        mock_encoding = MagicMock()
-        mock_encoding.encode = lambda x: x.split()
-        mock_encoding_for_model.return_value = mock_encoding
-
-        counter = TokenCounter(model="gpt-4o")
-        messages = [{"content": "Hello"}, {"content": "How are you?"}]
-        assert counter(messages=messages) > 0
-        assert counter(text="Hello") > 0
-
-    @patch("tiktoken.encoding_for_model")
-    @patch("openai.resources.chat.completions.Completions.create")
-    @patch("os.path.exists", return_value=True)
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data='{"test-model": {"model": "test-model", "max_tokens": 100, "tokenizer": "gpt-4o", "context_limit": 4, "api_key": "test-api-key", "endpoint": "https://test-endpoint", "api_version": "v1", "tags": ["azure openai"]}}',
     )
-    def test_llm(self, mock_open, mock_exists, mock_openai, mock_encoding_for_model):
-        mock_encoding = MagicMock()
-        mock_encoding.encode = lambda x: x.split()
-        mock_encoding_for_model.return_value = mock_encoding
+    monkeypatch.setenv("LLM_CONFIG_FILE", str(config_file))
+    return config_file
 
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Response"
-        mock_openai.return_value = mock_response
 
-        llm = LLM(model_name="test-model", verbose=False)
-        messages = [{"role": "user", "content": "Hello"}]
-        response, token_usage = llm(messages)
-        assert response == "Response"
-        assert "prompt" in token_usage
-        assert "response" in token_usage
+def test_load_llm_config(llm_config_mock):
+    config = load_llm_config()
+    assert "test_model" in config
 
-    @pytest.mark.asyncio
-    @patch("llm_api.AsyncAzureOpenAI")
-    async def test_async_llm(mock_async_openai):
-        mock_async_openai.return_value.chat.completions.create.return_value.choices[
-            0
-        ].message.content = "Response"
-        llm = AsyncLLM(model_name="test_model", verbose=False)
-        messages = [{"role": "user", "content": "Hello"}]
-        response, token_usage = await llm(messages)
-        assert response == "Response"
-        assert "prompt" in token_usage
-        assert "response" in token_usage
 
-    @pytest.mark.asyncio
-    @patch("llm_api.AsyncLLM.query_model", new_callable=AsyncMock)
-    @patch(
-        "llm_api.merge_messages",
-        return_value=[{"role": "user", "content": "Test message"}],
-    )
-    @patch(
-        "llm_api.trim_prompt_messages",
-        return_value=[{"role": "user", "content": "Test message"}],
-    )
-    async def test_async_llm_call(mock_trim, mock_merge, mock_query_model, async_llm):
-        # Set up the mock return value for query_model
-        mock_query_model.return_value = "Test response"
+def test_load_llm_config_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_llm_config(str(tmp_path / "llm.cfg"))
 
-        # Define the input messages
-        messages = [{"role": "user", "content": "Test message"}]
 
-        # Call the __call__ method
-        response, token_usage = await async_llm(messages)
+@pytest.fixture
+def completion_mock():
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "some completion mock."
+    return AsyncMock(return_value=mock_response)
 
-        # Assert the response and token usage
-        assert response == "Test response"
-        assert token_usage == {
-            "prompt": async_llm.token_counter(messages=messages),
-            "response": async_llm.token_counter(text="Test response"),
-        }
 
-        # Assert that the mock methods were called
-        mock_merge.assert_called_once_with(messages)
-        mock_trim.assert_called_once_with(
-            [{"role": "user", "content": "Test message"}],
-            async_llm.context_length,
-            async_llm.token_counter,
-        )
-        mock_query_model.assert_called_once_with(
-            [{"role": "user", "content": "Test message"}]
-        )
+@pytest.mark.asyncio
+async def test_async_llm(llm_config_mock, completion_mock, logger_mock):
+    llm = AsyncLLM(model_name="test_model", logger=logger_mock)
+    llm.client.chat.completions.create = completion_mock
+    messages = [{"role": "user", "content": "Hello"}]
+    response, token_usage = await llm(messages)
+    assert response == "some completion mock."
+    assert token_usage == {"prompt": 1, "response": 4}
 
-    @patch("builtins.input", return_value="User input")
-    def test_human(self, mock_prompt):
-        human = Human()
-        messages = [{"role": "user", "content": "Hello"}]
-        info = {"available_commands": ["command1", "command2"]}
-        response, token_usage = human(messages, info)
-        assert response == "User input"
-        assert "prompt" in token_usage
-        assert "response" in token_usage
 
-    def test_random(self):
-        random_llm = Random(seed=42, verbose=False)
-        messages = [{"role": "user", "content": "Hello"}]
-        info = {"available_commands": ["command1", "command2"]}
-        response, token_usage = random_llm(messages, info)
-        assert response in ["command1", "command2"]
-        assert "prompt" in token_usage
-        assert "response" in token_usage
+@patch("builtins.input", lambda *args, **kwargs: "User input")
+@patch("froggy.agents.llm_api.prompt", lambda *args, **kwargs: "User input")
+def test_human():
+    human = Human()
+    messages = [{"role": "user", "content": "Hello"}]
+    info = {"available_commands": ["command1", "command2"]}
+    response, token_usage = human(messages, info)
+    assert response == "User input"
+    assert "prompt" in token_usage
+    assert "response" in token_usage
 
-    @patch("tiktoken.encoding_for_model")
-    @patch("os.path.exists", return_value=True)
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data='{"test-model": {"model": "test-model", "max_tokens": 100, "tokenizer": "gpt-4o", "context_limit": 4, "api_key": "test-api-key", "endpoint": "https://test-endpoint", "api_version": "v1", "tags": ["azure openai"]}}',
-    )
-    def test_instantiate_llm(self, mock_open, mock_exists, mock_encoding_for_model):
-        mock_encoding = MagicMock()
-        mock_encoding.encode = lambda x: x.split()
-        mock_encoding_for_model.return_value = mock_encoding
 
-        config = {"llm_name": "test-model"}
-        llm = instantiate_llm(config, verbose=False, use_async=False)
-        assert isinstance(llm, LLM)
+def test_random(logger_mock):
+    random_llm = Random(seed=42, logger=logger_mock)
+    messages = [{"role": "user", "content": "Hello"}]
+    info = {"available_commands": ["command1", "command2"]}
+    response, token_usage = random_llm(messages, info)
+    assert response in ["command1", "command2"]
+    assert "prompt" in token_usage
+    assert "response" in token_usage
 
-        config = {"llm_name": "random", "random_seed": 42}
-        llm = instantiate_llm(config, verbose=False, use_async=False)
-        assert isinstance(llm, Random)
 
-        config = {"llm_name": "human"}
-        llm = instantiate_llm(config, verbose=False, use_async=False)
-        assert isinstance(llm, Human)
+@patch("tiktoken.encoding_for_model")
+@patch("os.path.exists", return_value=True)
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data='{"test-model": {"model": "test-model", "max_tokens": 100, "tokenizer": "gpt-4o", "context_limit": 4, "api_key": "test-api-key", "endpoint": "https://test-endpoint", "api_version": "v1", "tags": ["azure openai"]}}',
+)
+def test_instantiate_llm(mock_open, mock_exists, mock_encoding_for_model, logger_mock):
+    mock_encoding = MagicMock()
+    mock_encoding.encode = lambda x: x.split()
+    mock_encoding_for_model.return_value = mock_encoding
+
+    config = {"llm_name": "test-model"}
+    llm = instantiate_llm(config, logger=logger_mock, use_async=False)
+    assert isinstance(llm, LLM)
+
+    config = {"llm_name": "random", "random_seed": 42}
+    llm = instantiate_llm(config, logger=logger_mock, use_async=False)
+    assert isinstance(llm, Random)
+
+    config = {"llm_name": "human"}
+    llm = instantiate_llm(config, logger=logger_mock, use_async=False)
+    assert isinstance(llm, Human)

--- a/froggy/tests/test_llm_api.py
+++ b/froggy/tests/test_llm_api.py
@@ -36,14 +36,14 @@ def logger_mock():
 
 
 @pytest.fixture
-def async_llm(logger_mock):
+def async_llm(logger_mock, llm_config_mock):
     # Create an instance of AsyncLLM with a mock configuration
-    model_name = "test-model"
+    model_name = "test_model"
     async_llm = AsyncLLM(model_name, logger=logger_mock)
     return async_llm
 
 
-def test_is_rate_limit_error():
+def test_is_rate_limit_error(async_llm):
     mock_response = MagicMock()
     mock_response.request = "example"
     mock_response.body = {"error": "Rate limit exceeded"}
@@ -51,7 +51,7 @@ def test_is_rate_limit_error():
     exception = RateLimitError(
         "Rate limit exceeded", response=mock_response, body=mock_response.body
     )
-    assert is_rate_limit_error(exception) == True
+    assert async_llm.is_rate_limit_error(exception) == True
 
 
 def test_print_messages(logger_mock):
@@ -163,7 +163,6 @@ async def test_async_llm(llm_config_mock, completion_mock, logger_mock):
 
 
 @patch("builtins.input", lambda *args, **kwargs: "User input")
-@patch("froggy.agents.llm_api.prompt", lambda *args, **kwargs: "User input")
 def test_human():
     human = Human()
     messages = [{"role": "user", "content": "Hello"}]

--- a/froggy/tests/test_tadpole.py
+++ b/froggy/tests/test_tadpole.py
@@ -75,7 +75,6 @@ class TestAgentTadpole(unittest.TestCase):
         messages = self.agent.build_prompt_step_2(info)
         self.assertGreater(len(messages), 0)
 
-    @patch("froggy.agents.tadpole.tqdm", MagicMock())
     def test_run(self):
         self.env.reset.return_value = (
             None,

--- a/froggy/tests/test_tadpole.py
+++ b/froggy/tests/test_tadpole.py
@@ -28,7 +28,7 @@ class TestAgentTadpole(unittest.TestCase):
         self.env = MagicMock()
         self.llm = MagicMock()
         self.history = MagicMock()
-        self.agent = AgentTadpole(self.config_dict, self.env, verbose=False)
+        self.agent = AgentTadpole(self.config_dict, self.env)
         self.agent.llm = self.llm
         self.agent.history = self.history
 

--- a/froggy/tests/test_utils.py
+++ b/froggy/tests/test_utils.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -402,4 +403,4 @@ def test_load_config():
     assert _config["cot"]["llm_name"] == "gpt20"
     assert _config["cot"]["llm_temperature"] == [0.8, 0.8]
     assert _args.debug is True
-    assert _args.logging_level == "DEBUG"
+    assert _args.logging_level == logging.DEBUG

--- a/froggy/tests/test_utils.py
+++ b/froggy/tests/test_utils.py
@@ -402,4 +402,4 @@ def test_load_config():
     assert _config["cot"]["llm_name"] == "gpt20"
     assert _config["cot"]["llm_temperature"] == [0.8, 0.8]
     assert _args.debug is True
-    assert _args.verbose is True
+    assert _args.logging_level == "DEBUG"

--- a/froggy/tests/test_zeroshot.py
+++ b/froggy/tests/test_zeroshot.py
@@ -32,7 +32,7 @@ class TestAgentZeroShot(unittest.TestCase):
         self.env = MagicMock()
         self.llm = MagicMock()
         self.history = MagicMock()
-        self.agent = AgentZeroShot(self.config_dict, self.env, verbose=False)
+        self.agent = AgentZeroShot(self.config_dict, self.env)
         self.agent.llm = self.llm
         self.agent.history = self.history
 
@@ -117,7 +117,7 @@ class TestAgentZeroShot_NoPDB(unittest.TestCase):
         self.env = MagicMock()
         self.llm = MagicMock()
         self.history = MagicMock()
-        self.agent = AgentZeroShot_NoPDB(self.config_dict, self.env, verbose=False)
+        self.agent = AgentZeroShot_NoPDB(self.config_dict, self.env)
         self.agent.llm = self.llm
         self.agent.history = self.history
 
@@ -168,9 +168,7 @@ class TestAgentZeroShot_PdbAfterRewrites(unittest.TestCase):
         self.env = MagicMock()
         self.llm = MagicMock()
         self.history = MagicMock()
-        self.agent = AgentZeroShot_PdbAfterRewrites(
-            self.config_dict, self.env, verbose=False
-        )
+        self.agent = AgentZeroShot_PdbAfterRewrites(self.config_dict, self.env)
         self.agent.llm = self.llm
         self.agent.history = self.history
 

--- a/froggy/tests/test_zeroshot.py
+++ b/froggy/tests/test_zeroshot.py
@@ -56,7 +56,6 @@ class TestAgentZeroShot(unittest.TestCase):
         messages = self.agent.build_prompt(info)
         self.assertGreater(len(messages), 0)
 
-    @patch("froggy.agents.zero_shot.tqdm", MagicMock())
     def test_run(self):
         self.env.reset.return_value = (
             None,
@@ -172,7 +171,6 @@ class TestAgentZeroShot_PdbAfterRewrites(unittest.TestCase):
         self.agent.llm = self.llm
         self.agent.history = self.history
 
-    @patch("froggy.agents.zero_shot.tqdm", MagicMock())
     def test_run(self):
         self.env.reset.return_value = (
             None,

--- a/froggy/utils.py
+++ b/froggy/utils.py
@@ -1,10 +1,12 @@
 import argparse
 import codecs
+import logging
 import os
 import re
 import signal
 from contextlib import contextmanager
 from os.path import join as pjoin
+from pathlib import Path
 from typing import Optional
 
 import yaml
@@ -187,6 +189,19 @@ def load_config():
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose mode")
     parser.add_argument(
+        "-vv", "--very-verbose", action="store_true", help="Set logging level to DEBUG"
+    )
+    parser.add_argument(
+        "--force-all",
+        action="store_true",
+        help="Force running all problems even if they are already done.",
+    )
+    parser.add_argument(
+        "--force-failed",
+        action="store_true",
+        help="Force running only problems that have failed.",
+    )
+    parser.add_argument(
         "-p",
         "--params",
         nargs="+",
@@ -209,3 +224,55 @@ def load_config():
         entry_to_change[keys[-1]] = yaml.safe_load(value)
 
     return config, args
+
+
+def setup_logger(
+    name: str,
+    log_dir: str | None = None,
+    verbose: bool = False,
+    mode="a",
+    progress=None,
+    task_id=None,
+):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    logger.progress = progress
+    logger.task_id = task_id
+
+    if progress is not None and task_id is not None:
+
+        class ProgressHandler(logging.Handler):
+            def emit(self, record):
+                # Strip color codes from the log message
+                message = re.sub(r"\x1b\[[0-9;]*m", "", self.format(record))
+                message = message.replace("\n", "\\n").replace("\r", "\\r")
+                # Truncate message to 80 characters
+                message = message[:80] + "..." if len(message) > 80 else message
+                progress.update(task_id, log=message)
+
+        ph = ProgressHandler()
+        ph.setLevel(logging.DEBUG if verbose else logging.INFO)
+        formatter = logging.Formatter("%(levelname)-8s %(message)s")
+        ph.setFormatter(formatter)
+        logger.addHandler(ph)
+
+    console = logging.StreamHandler()
+    formatter = logging.Formatter("🐸 [%(name)-12s]: %(levelname)-8s %(message)s")
+    console.setFormatter(formatter)
+    console.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.addHandler(console)
+
+    if log_dir:
+        log_dir = Path(log_dir)
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.log_file = log_dir / f"{name}.log"
+        fh = logging.FileHandler(logger.log_file, mode=mode)
+        formatter = logging.Formatter("%(asctime)s %(levelname)-8s %(message)s")
+        fh.setFormatter(formatter)
+        fh.setLevel(logging.DEBUG)
+        logger.addHandler(fh)
+
+    # Prevent the log messages from being propagated to the root logger
+    logger.propagate = False
+    return logger

--- a/froggy/utils.py
+++ b/froggy/utils.py
@@ -1,5 +1,6 @@
 import argparse
 import codecs
+import logging
 import os
 import re
 import signal
@@ -185,9 +186,20 @@ def load_config():
     parser.add_argument(
         "--debug", action="store_true", help="Before sending action to the environment."
     )
-    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose mode")
-    parser.add_argument(
-        "-vv", "--very-verbose", action="store_true", help="Set logging level to DEBUG"
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-v",
+        "--verbose",
+        dest="logging_level",
+        action="store_const",
+        const=logging.DEBUG,
+        help="Verbose mode",
+    )
+    group.add_argument(
+        "--logging-level",
+        dest="logging_level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging level",
     )
     parser.add_argument(
         "--force-all",

--- a/froggy/utils.py
+++ b/froggy/utils.py
@@ -202,6 +202,11 @@ def load_config():
         help="Force running only problems that have failed.",
     )
     parser.add_argument(
+        "--keep-completed-tasks",
+        action="store_true",
+        help="Keep displaying completed tasks in the workers panel.",
+    )
+    parser.add_argument(
         "-p",
         "--params",
         nargs="+",
@@ -243,6 +248,9 @@ def setup_logger(
 
         class ProgressHandler(logging.Handler):
             def emit(self, record):
+                if task_id not in progress.tasks:
+                    return
+
                 # Strip color codes from the log message
                 message = re.sub(r"\x1b\[[0-9;]*m", "", self.format(record))
                 message = message.replace("\n", "\\n").replace("\r", "\\r")

--- a/scripts/config_aider.yaml
+++ b/scripts/config_aider.yaml
@@ -23,8 +23,8 @@ zero_shot:
 
     # Agent configs
     random_seed: 42
-    max_steps: 100
-    max_rewrite_steps: 1
+    max_steps: 20
+    max_rewrite_steps: 3
     memory_size: 20
     use_conversational_prompt: True
     save_patch: True

--- a/scripts/config_aider.yaml
+++ b/scripts/config_aider.yaml
@@ -11,20 +11,20 @@ zero_shot:
     }
     tools: ["pdb", "view", "patcher:substitution"]
     terminal: {
-        type: "local",  # "docker" or "local"
+        type: "docker",  # "docker" or "local"
         base_image: "python:3.12-slim",
-        # setup_commands: ["pip install pytest"]
+        setup_commands: ["pip install pytest"]
     }
     persistent_breakpoints: True  # in pdb tool
 
     # LLM configs
-    llm_name: "gpt-4o-mini"
+    llm_name: "llama-31-h100"
     llm_temperature: [0.0]  # list of values between 0.0 and 1.0
 
     # Agent configs
     random_seed: 42
-    max_steps: 20
-    max_rewrite_steps: 3
+    max_steps: 100
+    max_rewrite_steps: 10
     memory_size: 20
     use_conversational_prompt: True
     save_patch: True

--- a/scripts/config_aider.yaml
+++ b/scripts/config_aider.yaml
@@ -11,20 +11,20 @@ zero_shot:
     }
     tools: ["pdb", "view", "patcher:substitution"]
     terminal: {
-        type: "docker",  # "docker" or "local"
+        type: "local",  # "docker" or "local"
         base_image: "python:3.12-slim",
-        setup_commands: ["pip install pytest"]
+        # setup_commands: ["pip install pytest"]
     }
     persistent_breakpoints: True  # in pdb tool
 
     # LLM configs
-    llm_name: "llama-31-h100"
+    llm_name: "gpt-4o-mini"
     llm_temperature: [0.0]  # list of values between 0.0 and 1.0
 
     # Agent configs
     random_seed: 42
     max_steps: 100
-    max_rewrite_steps: 10
+    max_rewrite_steps: 1
     memory_size: 20
     use_conversational_prompt: True
     save_patch: True

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,20 +1,26 @@
-import asyncio
+import json
 import logging
 import os
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from os.path import join as pjoin
+from pathlib import Path
 
-from rich.progress import BarColumn, Progress, TextColumn
+from rich.console import Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+from rich.table import Column
 from termcolor import colored
-from tqdm import tqdm
 
 from froggy.tools.toolbox import Toolbox
-from froggy.utils import load_config
-
-logger = logging.getLogger("froggy")
+from froggy.utils import load_config, setup_logger
 
 
-def select_terminal(terminal_config: None):
+class BreakTaskLoop(Exception):
+    pass
+
+
+def select_terminal(terminal_config: dict | None, logger: logging.Logger):
     terminal_config = terminal_config or {"type": "local"}
     terminal_type = terminal_config["type"]
     match terminal_type:
@@ -25,7 +31,7 @@ def select_terminal(terminal_config: None):
         case _:
             raise ValueError(f"Unknown terminal {terminal_type}")
 
-    return terminal_class(**terminal_config)
+    return terminal_class(logger=logger, **terminal_config)
 
 
 def select_env(env_type: str = None):
@@ -43,28 +49,81 @@ def select_env(env_type: str = None):
     return env_class
 
 
-def run_agent(args, problem, config):
-    agent = create_agent(args, config)
+def run_agent(args, problem, config, task_progress: Progress, live):
+    config["uuid"] = config.get("uuid", str(uuid.uuid4()))
+    exp_path = Path(config["output_path"]) / config["uuid"] / problem
+    # add progress bar for steps of this app, and run the steps
+    current_task_id = task_progress.add_task(f"\\[{problem}]:", log="Starting task...")
 
-    if os.path.exists(pjoin(agent._output_path, problem, "froggy.jsonl")):
-        print(colored(f"Skipping {problem}, already done.", "yellow"))
-        return
+    task_logger = setup_logger(
+        problem,
+        log_dir=exp_path,
+        verbose=args.very_verbose,
+        mode="w" if args.force_all else "a",
+        progress=task_progress,
+        task_id=current_task_id,
+    )
+    task_logger.live = live
+    try:
+        previous_run = exp_path / "froggy.jsonl"
+        if not args.force_all and os.path.exists(previous_run):
+            task_logger.debug(f"Previous run found: {previous_run}")
+            with open(previous_run) as reader:
+                success = json.load(reader)["success"]
 
-    done = agent.run(task_name=problem, debug=args.debug)
+            task_logger.debug(f"Previous run success: {success}")
+            if not args.force_failed or success:
+                task_logger.info(f"Skipping {problem}, already done.")
+                task_progress.stop_task(current_task_id)
+                task_progress.update(
+                    current_task_id,
+                    completed=True,
+                    description=f"[bold gray]\\[{problem}]:",
+                    log="[bold gray]Skipped!",
+                )
+                task_progress.remove_task(current_task_id)
+                return success
 
-    # optionally apply patch
-    if config["save_patch"]:
-        agent.save_patch(task_name=problem)
+        env = create_env(args, config, task_logger)
+        agent = create_agent(args.agent, config=config, env=env, logger=task_logger)
+        success = agent.run(task_name=problem, debug=args.debug)
 
-    # save log
-    agent.log(task_name=problem)
-    return done
+        # optionally apply patch
+        if config["save_patch"]:
+            agent.save_patch(task_name=problem)
+
+        # save log
+        agent.log(task_name=problem)
+    except KeyboardInterrupt:
+        raise BreakTaskLoop
+
+    except Exception as e:
+        task_logger.warning(
+            f"Task Error: {problem} - {e!r}. Run with --very-verbose or check {task_logger.log_file} for more information."
+        )
+        task_logger.debug(
+            f"Task {problem} generated an exception: {e!r}", exc_info=True
+        )
+        if args.debug:
+            raise e
+
+        success = False
+
+    task_progress.stop_task(current_task_id)
+    task_progress.update(
+        current_task_id,
+        completed=True,
+        description=f"[bold green]\\[{problem}]:",
+        log="[bold green]Completed!",
+    )
+    task_progress.remove_task(current_task_id)
+    return success
 
 
-def create_env(args, config):
-    terminal = select_terminal(config.get("terminal"))
+def create_env(args, config: dict, logger: logging.Logger):
+    terminal = select_terminal(config.get("terminal"), logger)
     env_class = select_env(config.get("benchmark"))
-    env = env_class(**config["env_kwargs"], terminal=terminal)
+    env = env_class(**config["env_kwargs"], terminal=terminal, logger=logger)
 
     # import tools to the environment
     for tool in config["tools"]:
@@ -76,52 +135,41 @@ def create_env(args, config):
         tool_instantiated = Toolbox.get_tool(tool, **kwargs)
         env.add_tool(tool_instantiated)
         logger.debug(f"Adding tool to toolbox: {tool_instantiated.__class__.__name__}")
+
     return env
 
 
-def create_agent(args, config):
-    env = create_env(args, config)
-
-    # instantiate agent
-    match args.agent:
+def create_agent(agent_type, **kwargs):
+    match agent_type:
         case "zero_shot":
-            from froggy.agents import AgentZeroShot
-
-            agent = AgentZeroShot(config, env, verbose=args.verbose)
+            from froggy.agents import AgentZeroShot as agent_class
         case "cot":
-            from froggy.agents import AgentCoT
-
-            agent = AgentCoT(config, env, verbose=args.verbose)
+            from froggy.agents import AgentCoT as agent_class
         case "tadpole":
-            from froggy.agents import AgentTadpole
-
-            agent = AgentTadpole(config, env, verbose=args.verbose)
+            from froggy.agents import AgentTadpole as agent_class
         case "zero_shot_nopdb":
-            from froggy.agents import AgentZeroShot_NoPDB
-
-            agent = AgentZeroShot_NoPDB(config, env, verbose=args.verbose)
+            from froggy.agents import AgentZeroShot_NoPDB as agent_class
         case "cot_nopdb":
-            from froggy.agents import AgentCoT_NoPDB
-
-            agent = AgentCoT_NoPDB(config, env, verbose=args.verbose)
+            from froggy.agents import AgentCoT_NoPDB as agent_class
         case "zero_shot_pdb_after_rewrites":
-            from froggy.agents import AgentZeroShot_PdbAfterRewrites
-
-            agent = AgentZeroShot_PdbAfterRewrites(config, env, verbose=args.verbose)
+            from froggy.agents import AgentZeroShot_PdbAfterRewrites as agent_class
         case "zero_shot_nopdb_whole":
-            from froggy.agents import AgentZeroShot_NoPDB
-
-            agent = AgentZeroShot_NoPDB(config, env, verbose=args.verbose)
+            from froggy.agents import AgentZeroShot_NoPDB as agent_class
         case _:
-            raise ValueError(f"Unknown agent {args.agent}")
+            raise ValueError(f"Unknown agent {agent_type}")
 
-    if args.verbose:
-        agent.llm.verbose = True
+    agent = agent_class(**kwargs)
+
     return agent
 
 
 def main():
     config, args = load_config()
+    if args.very_verbose:
+        args.verbose = True
+
+    logger = setup_logger("froggy", verbose=args.very_verbose)
+
     available_agents = list(config.keys())
     assert (
         args.agent in available_agents
@@ -129,48 +177,106 @@ def main():
 
     config = config[args.agent]
 
-    env = create_env(args, config)
-
     # run agent, loop over the tasks
     if "benchmark" in config and "problems" in config:
         if "all" == config["problems"]:
+            env = create_env(args, config, logger=logger)
             problem_list = env.dataset.keys()  # all tasks
         else:
             assert isinstance(config["problems"], list)
             problem_list = config["problems"]
 
-        num_workers = 1 if args.verbose else int(os.environ.get("FROGGY_WORKERS", 1))
+        num_workers = int(os.environ.get("FROGGY_WORKERS", 1))
         tasks_done = 0
         mean_perf = 0
 
-        pbar = tqdm(range(len(problem_list)))
-        with ThreadPoolExecutor(num_workers) as executor:
-            futures = [
-                executor.submit(run_agent, args, problem, config)
-                for problem in problem_list
-            ]
-            for future in as_completed(futures):
-                try:
-                    result = future.result()
-                except Exception as e:
-                    print(f"Task generated an exception: {e}")
-                    continue  # Skip to the next future if desired
+        # progress bar for current task(s)
+        task_progress = Progress(
+            TimeElapsedColumn(),
+            BarColumn(bar_width=10),
+            TextColumn("{task.description}"),
+            TextColumn(
+                "{task.fields[log]}", table_column=Column(no_wrap=True)  # , width=80)
+            ),
+        )
 
-                mean_perf += result
-                tasks_done += 1
+        tasks_succeeded = []
+        overall_progress = Progress(
+            TextColumn("🐸"),
+            TimeElapsedColumn(),
+            BarColumn(),
+            TextColumn("{task.description}"),
+        )
 
-                pbar.set_description_str(
-                    f"Avg. Score so far: {mean_perf / tasks_done:.2f}"
-                )
-                pbar.update()
+        progress_group = Group(
+            Panel(task_progress, title="Workers"),
+            overall_progress,
+        )
+
+        overall_task_id = overall_progress.add_task("", total=len(problem_list))
+        top_descr = "[bold #AAAAAA](%d out of %d tasks done)" % (
+            tasks_done,
+            len(problem_list),
+        )
+        overall_progress.update(overall_task_id, description=top_descr, advance=0)
+
+        with Live(progress_group, refresh_per_second=20) as live:
+            if args.debug:
+                live.stop()  # Because it interferes with pdb.
+
+            with ThreadPoolExecutor(num_workers) as executor:
+                futures = {
+                    executor.submit(
+                        run_agent, args, problem, config, task_progress, live
+                    ): problem
+                    for problem in problem_list
+                }
+                for future in as_completed(futures):
+                    if future.cancelled():
+                        continue
+                    try:
+                        problem = futures[future]
+                        success = future.result()
+                        mean_perf += success
+                        tasks_done += 1
+
+                        if success:
+                            tasks_succeeded.append(problem)
+
+                        # update message on overall progress bar
+                        top_descr = (
+                            f"[bold #AAAAAA]({tasks_done} out of {len(problem_list)} tasks "
+                            f"done - [bold green]{mean_perf}[bold #AAAAAA] are successful)"
+                        )
+                        overall_progress.update(
+                            overall_task_id, description=top_descr, advance=1
+                        )
+                    except (KeyboardInterrupt, BreakTaskLoop):
+                        live.stop()
+                        executor.shutdown(wait=False, cancel_futures=True)
+                    except Exception as e:
+                        live.stop()
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        raise e
+
+            # final update for message on overall progress bar
+            overall_progress.update(
+                overall_task_id,
+                description=f"[bold green]{mean_perf}/{tasks_done} success!",
+            )
+
+        logger.info(f"Tasks that succeeded: {tasks_succeeded}")
     else:
         # custom repo
         print(colored(f"Running agent {agent.name}", "green"))
-        agent = create_agent(args, config)
+        env = create_env(args, config)
+        agent = create_agent(args, config=config, env=env, logger=logger)
         agent.run(debug=args.debug)
+
         # optionally apply patch
         if config["save_patch"]:
             agent.save_patch()
+
         # save log
         agent.log()
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -52,7 +52,7 @@ def run_agent(args, problem, config):
     task_logger = FroggyLogger(
         problem,
         log_dir=exp_path,
-        verbose=args.very_verbose,
+        level=args.logging_level,
         mode="w" if args.force_all else "a",
     )
     try:
@@ -143,10 +143,7 @@ def create_agent(agent_type, **kwargs):
 
 def main():
     config, args = load_config()
-    if args.very_verbose:
-        args.verbose = True
-
-    logger = FroggyLogger("froggy", verbose=args.very_verbose)
+    logger = FroggyLogger("froggy", level=args.logging_level)
 
     available_agents = list(config.keys())
     assert (

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,26 +1,22 @@
 import json
-import logging
 import os
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from rich.console import Group
 from rich.live import Live
-from rich.panel import Panel
-from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
-from rich.table import Column
 from termcolor import colored
 
+from froggy.logger import FroggyLogger
 from froggy.tools.toolbox import Toolbox
-from froggy.utils import load_config, setup_logger
+from froggy.utils import load_config
 
 
 class BreakTaskLoop(Exception):
     pass
 
 
-def select_terminal(terminal_config: dict | None, logger: logging.Logger):
+def select_terminal(terminal_config: dict | None, logger: FroggyLogger):
     terminal_config = terminal_config or {"type": "local"}
     terminal_type = terminal_config["type"]
     match terminal_type:
@@ -49,21 +45,16 @@ def select_env(env_type: str = None):
     return env_class
 
 
-def run_agent(args, problem, config, task_progress: Progress, live):
+def run_agent(args, problem, config):
     config["uuid"] = config.get("uuid", str(uuid.uuid4()))
     exp_path = Path(config["output_path"]) / config["uuid"] / problem
-    # add progress bar for steps of this app, and run the steps
-    current_task_id = task_progress.add_task(f"\\[{problem}]:", log="Starting task...")
 
-    task_logger = setup_logger(
+    task_logger = FroggyLogger(
         problem,
         log_dir=exp_path,
         verbose=args.very_verbose,
         mode="w" if args.force_all else "a",
-        progress=task_progress,
-        task_id=current_task_id,
     )
-    task_logger.live = live
     try:
         previous_run = exp_path / "froggy.jsonl"
         if not args.force_all and os.path.exists(previous_run):
@@ -73,15 +64,8 @@ def run_agent(args, problem, config, task_progress: Progress, live):
 
             task_logger.debug(f"Previous run success: {success}")
             if not args.force_failed or success:
-                task_logger.info(f"Skipping {problem}, already done.")
-                task_progress.stop_task(current_task_id)
-                task_progress.update(
-                    current_task_id,
-                    completed=True,
-                    description=f"[bold gray]\\[{problem}]:",
-                    log="[bold gray]Skipped!",
-                )
-                task_progress.remove_task(current_task_id)
+                task_logger.info("[bold gray]Skipped, already done.")
+                task_logger.stop(remove=not args.keep_completed_tasks)
                 return success
 
         env = create_env(args, config, task_logger)
@@ -109,20 +93,12 @@ def run_agent(args, problem, config, task_progress: Progress, live):
 
         success = False
 
-    task_progress.stop_task(current_task_id)
-    task_progress.update(
-        current_task_id,
-        completed=True,
-        description=f"[bold green]\\[{problem}]:",
-        log="[bold green]Completed!",
-    )
-    if not args.keep_completed_tasks:
-        task_progress.remove_task(current_task_id)
-
+    task_logger.info("[bold green]Completed!")
+    task_logger.stop(remove=not args.keep_completed_tasks)
     return success
 
 
-def create_env(args, config: dict, logger: logging.Logger):
+def create_env(args, config: dict, logger: FroggyLogger):
     terminal = select_terminal(config.get("terminal"), logger)
     env_class = select_env(config.get("benchmark"))
     env = env_class(**config["env_kwargs"], terminal=terminal, logger=logger)
@@ -170,7 +146,7 @@ def main():
     if args.very_verbose:
         args.verbose = True
 
-    logger = setup_logger("froggy", verbose=args.very_verbose)
+    logger = FroggyLogger("froggy", verbose=args.very_verbose)
 
     available_agents = list(config.keys())
     assert (
@@ -192,45 +168,24 @@ def main():
         tasks_done = 0
         mean_perf = 0
 
-        # progress bar for current task(s)
-        task_progress = Progress(
-            TimeElapsedColumn(),
-            BarColumn(bar_width=10),
-            TextColumn("{task.description}"),
-            TextColumn(
-                "{task.fields[log]}", table_column=Column(no_wrap=True)  # , width=80)
-            ),
-        )
-
         tasks_succeeded = []
-        overall_progress = Progress(
-            TextColumn("🐸"),
-            TimeElapsedColumn(),
-            BarColumn(),
-            TextColumn("{task.description}"),
-        )
 
-        progress_group = Group(
-            Panel(task_progress, title="Workers"),
-            overall_progress,
-        )
-
-        overall_task_id = overall_progress.add_task("", total=len(problem_list))
+        overall_task_id = logger.overall_progress.add_task("", total=len(problem_list))
         top_descr = "[bold #AAAAAA](%d out of %d tasks done)" % (
             tasks_done,
             len(problem_list),
         )
-        overall_progress.update(overall_task_id, description=top_descr, advance=0)
+        logger.overall_progress.update(
+            overall_task_id, description=top_descr, advance=0
+        )
 
-        with Live(progress_group, refresh_per_second=20) as live:
+        with Live(logger.progress_group, refresh_per_second=20) as live:
             if args.debug:
                 live.stop()  # Because it interferes with pdb.
 
             with ThreadPoolExecutor(num_workers) as executor:
                 futures = {
-                    executor.submit(
-                        run_agent, args, problem, config, task_progress, live
-                    ): problem
+                    executor.submit(run_agent, args, problem, config): problem
                     for problem in problem_list
                 }
                 for future in as_completed(futures):
@@ -250,19 +205,20 @@ def main():
                             f"[bold #AAAAAA]({tasks_done} out of {len(problem_list)} tasks "
                             f"done - [bold green]{mean_perf}[bold #AAAAAA] are successful)"
                         )
-                        overall_progress.update(
+                        logger.overall_progress.update(
                             overall_task_id, description=top_descr, advance=1
                         )
-                    except (KeyboardInterrupt, BreakTaskLoop):
+                    except (KeyboardInterrupt, BreakTaskLoop) as e:
                         live.stop()
                         executor.shutdown(wait=False, cancel_futures=True)
+                        raise e
                     except Exception as e:
                         live.stop()
                         executor.shutdown(wait=False, cancel_futures=True)
                         raise e
 
             # final update for message on overall progress bar
-            overall_progress.update(
+            logger.overall_progress.update(
                 overall_task_id,
                 description=f"[bold green]{mean_perf}/{tasks_done} success!",
             )

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -116,7 +116,9 @@ def run_agent(args, problem, config, task_progress: Progress, live):
         description=f"[bold green]\\[{problem}]:",
         log="[bold green]Completed!",
     )
-    task_progress.remove_task(current_task_id)
+    if not args.keep_completed_tasks:
+        task_progress.remove_task(current_task_id)
+
     return success
 
 


### PR DESCRIPTION
In addition to switch to logging (file and stdout) instead of print, and adding a nice progress visualization (see image), this pull request also includes the following changes:
- Remove the explicit `_uuid` params in the `AgentBase` (other agents) constructor and use the `uuid` field from the `config` dictionary instead.
- Add typing
- Move the `is_rate_limit_error` inside the `LLM` class (needed for logging).
- Set a timeout of 1 second to stop container (instead of the default which is 10 secs).
- Provide an example in `zero_shot.py` of how we could log progress instead of using tqdm. 

![image](https://github.com/user-attachments/assets/a7f2d495-3a86-407f-bd15-22c8e89089a4)
