### PR TITLE
LLM Returns None

### DIFF
--- a/froggy/agents/llm_api.py
+++ b/froggy/agents/llm_api.py
@@ -255,6 +255,8 @@ class LLM:
         print_messages(messages, self.logger)
 
         response = self.query_model(messages, **kwargs)
+        if response is None:
+            response = ""
         response = response.strip()
 
         self.logger.info(colored(response, "green"))


### PR DESCRIPTION
Tackling cases where the LLM failed to return anything:
![image](https://github.com/user-attachments/assets/6c17c5ca-8e91-4b07-9ca3-8701280040f5)
