### PR TITLE
Disable strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ We provide the below LLM-based agents, they all have minimal design and serve th
 
 | Agent name | Available Tools | Description |
 | :-: | :-: | :----- |
-| `debug_agent` | `pdb`, `patcher`, `view`, `eval` | A minimal agent that dumps all available information into its prompt and queries the LLM to generate a command. |
-| `rewrite_agent` | `patcher`, `view`, `eval`  | A `debug_agent` but `pdb` tool is disabled (an agent keeps rewriting). |
-| `debug_5_agent` | `pdb`, `patcher`, `view`, `eval`  | A `debug_agent`, but `pdb` tool is only enabled after certain amount of rewrites. |
+| `debug_agent` | `pdb`, `rewrite`, `view`, `eval` | A minimal agent that dumps all available information into its prompt and queries the LLM to generate a command. |
+| `rewrite_agent` | `rewrite`, `view`, `eval`  | A `debug_agent` but `pdb` tool is disabled (an agent keeps rewriting). |
+| `debug_5_agent` | `pdb`, `rewrite`, `view`, `eval`  | A `debug_agent`, but `pdb` tool is only enabled after certain amount of rewrites. |
 
 ---
 
@@ -119,14 +119,17 @@ Add `-v`, `--debug` to be verbose, or to enter debug mode.
 > [!WARNING]
 > When using --debug, you will need to press `c` to continue after each reasoning step.
 
+#### 3.1 Human Mode
 
-#### 3.1. Overriding Values in Config
+We provide a human mode that enables developers to manually interact with `debug-gym`. To activate this mode, change the `llm_name` field in the `config_*.yaml` to be `"human"`. Once activated, at every step, the environment will expect a command input (in tool calling format). One can use the `Tab` key to get a list of tool calling templates and fill in any necessary arguments.
+
+#### 3.2. Overriding Values in Config
 
 `-p` is a handy way to override values defined in config. For example, the below command will run rewrite_agent agent on Aider with human mode (while in config file it specifies gpt-4o).
 
     python scripts/run.py scripts/config_aider.yaml --agent rewrite_agent -v -p rewrite_agent.llm_name="human"
 
-#### 3.2. Debugging a Custom Repository
+#### 3.3. Debugging a Custom Repository
 
 Modify `scripts/config.yaml`, especially the `env_kwargs` to set the path and entrypoint of the custom repository. We assume there is a `.debugignore` file and a `.debugreadonly` within the repository that labels files/folders that are not seen or not editable, respectively.
 
@@ -134,7 +137,7 @@ As an example, we provide a buggy pytorch code repository in `data/pytorch`.
 
     python scripts/run.py scripts/config.yaml --agent <agent name>
 
-#### 3.3. Design Your Own Tool
+#### 3.4. Design Your Own Tool
 `debug-gym`'s modular design makes it extensible. Users are encouraged to extend `debug-gym` to their specific usecases, for example by creating new tools that diversify an agent's action and observation spaces. For detailed instruction on designing new tools that are `debug-gym`-compatible, please refer to the [Technical Report](https://arxiv.org/abs/2503.21557).
 
 ## Citation

--- a/debug_gym/agents/base_agent.py
+++ b/debug_gym/agents/base_agent.py
@@ -153,7 +153,7 @@ class BaseAgent:
         if info.done is True:
             return True
         self.logger.info(
-            f"Available tools (in LLM's tool calling format):\n{json.dumps(self.llm.define_tools(info.tools))}\n"
+            f"Available tools (in LLM's tool calling format):\n{json.dumps(self.llm.define_tools(info.tools), indent=4)}\n"
         )
 
         highscore = info.score

--- a/debug_gym/agents/base_agent.py
+++ b/debug_gym/agents/base_agent.py
@@ -152,6 +152,9 @@ class BaseAgent:
 
         if info.done is True:
             return True
+        self.logger.info(
+            f"Available tools (in LLM's tool calling format):\n{json.dumps(self.llm.define_tools(info.tools))}\n"
+        )
 
         highscore = info.score
 
@@ -213,6 +216,7 @@ class BaseAgent:
         jsonl_output = {
             "problem": task_name,
             "config": self.config,
+            "tools": self.llm.define_tools(self.env.tools),
             "uuid": self._uuid,
             "success": self.env.done,
             "log": [],

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -241,6 +241,8 @@ class RepoEnv(TooledEnv):
             self.debug_entrypoint = self.debug_entrypoint.replace(
                 "python", "python -m pdb"
             )
+        self.entrypoint = "PYTHONPATH=$PYTHONPATH:$PWD " + self.entrypoint
+        self.debug_entrypoint = "PYTHONPATH=$PYTHONPATH:$PWD " + self.debug_entrypoint
 
     @staticmethod
     def _prepare_entrypoint(entrypoint):

--- a/debug_gym/gym/tools/eval.py
+++ b/debug_gym/gym/tools/eval.py
@@ -9,8 +9,8 @@ class EvalTool(EnvironmentTool):
     description = "Evaluate the current code against pre-defined test cases."
     arguments = {}
 
-    def use(self, environment, **kwargs) -> Observation:
-        eval_output = environment.eval(**kwargs)
+    def use(self, environment) -> Observation:
+        eval_output = environment.eval()
         return Observation(self.name, eval_output.output)
 
     def on_env_reset(self, environment, **kwargs):

--- a/debug_gym/gym/tools/tool.py
+++ b/debug_gym/gym/tools/tool.py
@@ -48,7 +48,13 @@ class EnvironmentTool(ABC):
     def __call__(self, *args, **kwargs) -> Observation:
         """Forwards `tool()` to the tool.use() method and
         tracks the history of tool usage."""
-        return self.use(*args, **kwargs)
+        try:
+            return self.use(*args, **kwargs)
+        except Exception as e:
+            # Handle exceptions and return an observation
+            return Observation(
+                self.name, str(e)
+            )  # to handle cases where the LLM hallucinates and provide invalid arguments
 
     def register(self, environment):
         from debug_gym.gym.envs.env import RepoEnv

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -174,6 +174,7 @@ def agent_setup(tmp_path, open_data):
             llm.reasoning_end_token = None
             llm.context_length = 4096
             llm.count_tokens = _length
+            llm.define_tools = lambda x: x
             agent = agent_class(config_dict, env)
             agent.llm = llm
             yield agent, env, llm

--- a/tests/gym/tools/test_tool.py
+++ b/tests/gym/tools/test_tool.py
@@ -142,26 +142,3 @@ def test_unregister_with_multiple_handlers():
     # Verify tool is no longer listening to any events
     assert tool not in env.event_hooks.event_listeners[Event.ENV_RESET]
     assert tool not in env.event_hooks.event_listeners[Event.ENV_STEP]
-
-
-def test_tool_call():
-    tool = FakeTool()
-    env = RepoEnv()
-
-    # Call the tool
-    observation = tool(env, action="test_action")
-    # Check the observation
-    assert isinstance(observation, Observation)
-    assert observation.source == "FakeTool"
-    assert observation.observation == "test_action"
-
-    # Call the tool with an invalid argument
-    observation = tool(env, invalid_action="test_action")
-    # Check the observation
-    assert isinstance(observation, Observation)
-    assert observation.source == "FakeTool"
-    # invalid argument
-    assert (
-        observation.observation
-        == "FakeTool.use() got an unexpected keyword argument 'invalid_action'"
-    )

--- a/tests/gym/tools/test_tool.py
+++ b/tests/gym/tools/test_tool.py
@@ -131,3 +131,26 @@ def test_unregister_with_multiple_handlers():
     # Verify tool is no longer listening to any events
     assert tool not in env.event_hooks.event_listeners[Event.ENV_RESET]
     assert tool not in env.event_hooks.event_listeners[Event.ENV_STEP]
+
+
+def test_tool_call():
+    tool = FakeTool()
+    env = RepoEnv()
+
+    # Call the tool
+    observation = tool(env, action="test_action")
+    # Check the observation
+    assert isinstance(observation, Observation)
+    assert observation.source == "FakeTool"
+    assert observation.observation == "test_action"
+
+    # Call the tool with an invalid argument
+    observation = tool(env, invalid_action="test_action")
+    # Check the observation
+    assert isinstance(observation, Observation)
+    assert observation.source == "FakeTool"
+    # invalid argument
+    assert (
+        observation.observation
+        == "FakeTool.use() got an unexpected keyword argument 'invalid_action'"
+    )


### PR DESCRIPTION
This pull request introduces several updates to improve the functionality, robustness, and documentation of the `debug-gym` project. The key changes include updates to the tool definitions and usage, enhanced error handling, and improvements to the documentation for better clarity and usability.

### Documentation Improvements:
* Updated the list of available tools in `README.md` to replace `patcher` with `rewrite` for agents (`debug_agent`, `rewrite_agent`, `debug_5_agent`) to reflect the correct toolset.
* Added a new section on "Human Mode" in `README.md`, explaining how to enable manual interaction with `debug-gym` by setting the `llm_name` to `"human"` in the configuration.

### Tool Handling Enhancements:
* Modified the `define_tools` method in `debug_gym/agents/llm_api.py` to remove the unsupported `"strict"` property, ensuring compatibility with reasoning models like `o3`.
* Enhanced the `parse_tool_call_response` method to handle `None` responses gracefully by returning a default `ToolCall` object with an `empty_tool_response` identifier.
* Updated the `generate` method to handle scenarios where no tool calls are made by the LLM, setting `tool_call` to `None` in such cases.

### Robustness Improvements:
* Added exception handling in the `__call__` method of tools in `debug_gym/gym/tools/tool.py` to catch errors (e.g., invalid arguments) and return an `Observation` with the error message.
* Simplified the `use` method of the `EvalTool` class in `debug_gym/gym/tools/eval.py` by removing unused arguments and ensuring compatibility with the environment's `eval` method.

### Logging Enhancements:
* Updated the `run` method in `debug_gym/agents/base_agent.py` to log the available tools in the LLM's tool-calling format for better debugging.
* Enhanced the `log` method in `debug_gym/agents/base_agent.py` to include the defined tools in the output JSON for improved traceability.