### PR TITLE
Fix: Use json.dumps for tool arguments in OpenAILLM

### DIFF
--- a/debug_gym/agents/llm_api.py
+++ b/debug_gym/agents/llm_api.py
@@ -788,7 +788,7 @@ class OpenAILLM(LLM):
                         "id": response[0].tool.id,
                         "function": {
                             "name": response[0].tool.name,
-                            "arguments": str(response[0].tool.arguments),
+                            "arguments": json.dumps(response[0].tool.arguments),
                         },
                     },
                 ],


### PR DESCRIPTION
## Description
- Replace `str(response[0].tool.arguments)` with `json.dumps(response[0].tool.arguments)` in `llm_api.py`

## Type of Change
- [x] Bug fix