### PR TITLE
Clean up pytest.ini, partially reverting #98

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Test with pytest - PR
         if: github.event_name == 'pull_request'
         run: |
-          pytest -k "not test_swe_bench"
+          DEBUG_GYM_DEBUG=1 pytest -vv -n 16 -k "not test_swe_bench" --cov=debug_gym --cov-report=term-missing --cov-fail-under=80 --timeout=300
       - name: Test with pytest
         if: github.event_name != 'pull_request'
         run: |
-          pytest --cov-fail-under=90
+          DEBUG_GYM_DEBUG=1 pytest -vv -n 16 --cov=debug_gym --cov-report=term-missing --cov-fail-under=85 --timeout=600

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,20 +1,3 @@
 [pytest]
 norecursedirs = data/*
 asyncio_default_fixture_loop_scope = function
-
-# specifies additional command-line options to be passed to the pytest test runner
-# -n    - run tests in parallel (pytest-xdist)
-# --cov - measure code coverage (pytest-cov)
-addopts =
-    -vv
-    -n 16
-    --cov=debug_gym
-    --cov-report=term-missing
-    --cov-fail-under=80
-
-# set environment variables for the test session (pytest-env)
-env =
-    DEBUG_GYM_DEBUG=1
-
-# per-test timeout, in seconds (pytest-timeout)
-timeout = 600


### PR DESCRIPTION
- Removing configs from pytest.ini, otherwise debugging or running individual tests also make use of multiple workers, coverage, and timeout... 😅 
- Adjust coverage threshold from 90% to 85% for the main branch (including swe-bench tests)

From Copilot:
This pull request updates the testing configuration to improve efficiency and maintainability. The changes include modifying the GitHub Actions workflow to enhance test execution and removing redundant settings from the `pytest.ini` configuration file.

### Updates to GitHub Actions workflow:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL36-R40): Updated the pytest commands to include parallel test execution (`-n 16`), increased verbosity (`-vv`), code coverage measurement (`--cov`), and timeouts. Environment variables are now set directly in the workflow. Adjusted coverage thresholds to 80% for pull requests and 85% for other events.

### Cleanup of `pytest.ini`:

* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1L4-L20): Removed redundant `addopts`, `env`, and `timeout` configurations, as these are now directly specified in the GitHub Actions workflow. This simplifies the configuration file and reduces duplication.