### PR TITLE
Fix kwargs for pdb tool

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -89,14 +89,7 @@ def create_env(config: dict, logger: DebugGymLogger):
 def add_tools(env, config: dict, logger: DebugGymLogger):
     """Add tools to the environment"""
     for tool in config["tools"]:
-        kwargs = {}
-        if tool == "pdb":
-            kwargs["persistent_breakpoints"] = config["env_kwargs"][
-                "persistent_breakpoints"
-            ]
-            kwargs["auto_list"] = config["env_kwargs"]["auto_list"]
-
-        tool_instantiated = Toolbox.get_tool(tool, **kwargs)
+        tool_instantiated = Toolbox.get_tool(tool)
         env.add_tool(tool_instantiated)
         logger.debug(f"Adding tool to toolbox: {tool_instantiated.__class__.__name__}")
 


### PR DESCRIPTION
No need to pass the kwargs when initializing the tool. Now the two args are part of the env. 