### PR TITLE
Enhance Agent logging to include step number and reason for termination

### DIFF
--- a/debug_gym/agents/base_agent.py
+++ b/debug_gym/agents/base_agent.py
@@ -166,7 +166,7 @@ class BaseAgent:
         for step in self.logger.tqdm(range(self.config["max_steps"])):
             highscore = max(highscore, info.score)
             self.logger.info(
-                f"Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%}) [Best: {highscore}]"
+                f"Step: {step} | Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%}) [Best: {highscore}]"
             )
 
             messages = self.build_prompt(info)
@@ -179,8 +179,9 @@ class BaseAgent:
             self.history.step(info, llm_response)
 
             if info.done or info.rewrite_counter >= self.config["max_rewrite_steps"]:
+                reason = "done" if info.done else "max_rewrite_steps reached"
                 self.logger.info(
-                    f"Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%})"
+                    f"Step: {step} | Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%}) | Reason: {reason}"
                 )
                 break
         return info.done

--- a/debug_gym/agents/debug_agent.py
+++ b/debug_gym/agents/debug_agent.py
@@ -30,7 +30,7 @@ class Debug_5_Agent(DebugAgent):
         for step in self.logger.tqdm(range(self.config["max_steps"])):
             highscore = max(highscore, info.score)
             self.logger.info(
-                f"Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%}) [Best: {highscore}]"
+                f"Step: {step} | Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%}) [Best: {highscore}]"
             )
 
             messages = self.build_prompt(info)
@@ -55,8 +55,9 @@ class Debug_5_Agent(DebugAgent):
             self.history.step(info, llm_response)
 
             if info.done or info.rewrite_counter >= self.config["max_rewrite_steps"]:
+                reason = "done" if info.done else "max_rewrite_steps reached"
                 self.logger.info(
-                    f"Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%})"
+                    f"Step: {step} | Score: {info.score}/{info.max_score} ({info.score/info.max_score:.1%}) | Reason: {reason}"
                 )
                 break
 


### PR DESCRIPTION
This pull request improves the logging output in the `run` method of both `BaseAgent` and `DebugAgent` by adding step information and the reason for termination to the log messages.

### Logging Enhancements:

* [`debug_gym/agents/base_agent.py`](diffhunk://#diff-769a128278122d779780df5a3a6a2d1ffa96e793d619dec71d091bf21368824eL169-R169): Updated log messages to include the current step and termination reason (e.g., "done" or "max_rewrite_steps reached") in the `run` method. [[1]](diffhunk://#diff-769a128278122d779780df5a3a6a2d1ffa96e793d619dec71d091bf21368824eL169-R169) [[2]](diffhunk://#diff-769a128278122d779780df5a3a6a2d1ffa96e793d619dec71d091bf21368824eR182-R184)

* [`debug_gym/agents/debug_agent.py`](diffhunk://#diff-872c89cb5a43ebc1e36269426eb653c84080edcbb0134bcc946b3a788cf09b47L33-R33): Made similar updates to log messages in the `run` method to include step information and termination reason for consistency with `BaseAgent`. [[1]](diffhunk://#diff-872c89cb5a43ebc1e36269426eb653c84080edcbb0134bcc946b3a788cf09b47L33-R33) [[2]](diffhunk://#diff-872c89cb5a43ebc1e36269426eb653c84080edcbb0134bcc946b3a788cf09b47R58-R60)