### PR TITLE
Pdb current frame file

### DIFF
--- a/debug_gym/gym/tools/pdb.py
+++ b/debug_gym/gym/tools/pdb.py
@@ -62,6 +62,7 @@ class PDBTool(EnvironmentTool):
 
     def close_pdb(self):
         self._session.close()
+        self.current_frame_file = None
 
     def start_pdb(self, environment) -> str:
         self._session = environment.terminal.new_shell_session()
@@ -81,6 +82,7 @@ class PDBTool(EnvironmentTool):
                     initial_output = "\n".join(
                         [initial_output, "Breakpoints have been restored."]
                     )
+            self.set_current_frame_file(environment)
         self.pdb_obs = initial_output
         return initial_output
 
@@ -104,14 +106,12 @@ class PDBTool(EnvironmentTool):
 
     def use(self, environment, command: str) -> Observation:
         _warning = ""
-        if (
+        # if print, it's OK to have ";" or "\n" in the command
+        if not (
             command == ""
             or command.split()[0] in ["p", "pp"]
             or command.startswith("print(")
         ):
-            # OK to have ";" or "\n" in the command
-            pass
-        else:
             splits = re.split("\n|;", command)
             if len(splits) > 1:
                 command = splits[0].strip()
@@ -122,6 +122,8 @@ class PDBTool(EnvironmentTool):
             output += self.start_pdb(environment)
 
         if not self.pdb_is_running:
+            # update the current frame file to None
+            self.set_current_frame_file(environment)
             return Observation(self.name, f"Failure calling pdb:\n{output}")
         if command == "":  # empty command
             return Observation(
@@ -130,7 +132,10 @@ class PDBTool(EnvironmentTool):
 
         if command in ["b", "break"]:
             # list all breakpoints
-            success, output = True, environment.current_breakpoints()
+            success, output = (
+                True,
+                f"Breakpoints:\n{environment.current_breakpoints()}\n",
+            )
         elif command in ["cl", "clear"]:
             # clear all breakpoints
             environment.current_breakpoints_state = {}
@@ -164,41 +169,40 @@ class PDBTool(EnvironmentTool):
             except Exception:  # TODO: catch specific exceptions
                 success = False
 
-        if success:
-            # sometimes it will run into the end of the program
-            # we need to put the stdout before:
-            # The program exited via sys.exit().
-            # into self.last_eval_output, and remove them from the output
-            if "The program exited via sys.exit()." in output:
-                # end index is the last occurrence of the program exited (from the \n after)
-                end_index = (
-                    output.find(
-                        "\n", output.rfind("The program exited via sys.exit().")
-                    )
-                    + 1
-                )
-                output = (
-                    "Reached the end of the file. Restarting the debugging session.\n"
-                    + output[end_index:]
-                )
-            obs = "\n".join([_warning, output]).strip()
-
-            # Add the current frame information to the observation.
-            if (
-                self.pdb_is_running
-                and environment.auto_list
-                and command.split()[0] not in ["l", "list"]
-            ):
-                if '"""The pytest entry point."""' not in obs:
-                    obs += "\nlist .\n" + self.interact_with_pdb(
-                        "l .", environment.run_timeout
-                    )
-        else:
+        if not success:
             obs = "\n".join([f"Invalid pdb command: {command}", _warning, output])
+            return Observation(self.name, obs)
 
+        # sometimes it will run into the end of the program
+        # we need to put the stdout before:
+        # The program exited via sys.exit().
+        # into self.last_eval_output, and remove them from the output
+        if "The program exited via sys.exit()." in output:
+            # end index is the last occurrence of the program exited (from the \n after)
+            end_index = (
+                output.find("\n", output.rfind("The program exited via sys.exit()."))
+                + 1
+            )
+            output = (
+                "Reached the end of the file. Restarting the debugging session.\n"
+                + output[end_index:]
+            )
+        obs = "\n".join([_warning, output]).strip() + "\n"
+
+        # Add the current frame information to the observation.
         if self.pdb_is_running:
             # read the current frame info to determine the current file
-            self.get_current_frame_file(environment)
+            current_frame = self.set_current_frame_file(environment)
+
+            # free 'list' to provide context around the current frame
+            list_output = ""
+            if environment.auto_list and command.split()[0] not in ["l", "list"]:
+                list_output = self.interact_with_pdb("l .", environment.run_timeout)
+
+            if current_frame:
+                obs += f"\nCurrent frame:\n{current_frame}\n"
+            if list_output:
+                obs += f"\nContext around the current frame:\n{list_output}\n"
 
         return Observation(self.name, obs)
 
@@ -336,11 +340,10 @@ class PDBTool(EnvironmentTool):
                     pass
         environment.current_breakpoints_state = current_breakpoints_state_copy
 
-    def get_current_frame_file(self, environment):
+    def set_current_frame_file(self, environment) -> str | None:
         """A free 'where' to obtain the current frame (line number), hidden from the agent."""
         command = "where"
         output = self.interact_with_pdb(command, environment.run_timeout)
-
         # parse the output to get the current frame
         # example output:
         #    /home/eryua/venvs/pdb/lib/python3.12/bdb.py(606)run()
@@ -348,15 +351,18 @@ class PDBTool(EnvironmentTool):
         #    <string>(1)<module>()
         # > /tmp/RepoEnv-_ha8r7_2/constants.py(6)<module>()
         # -> ACTION_TO_INDEX = {
-        sep = "> " + str(environment.working_dir) + "/"
-        if sep not in output:
-            return
-        output = output.rsplit(sep, 1)[1]
-        # constants.py(6)<module>()
-        # -> ACTION_TO_INDEX = {
-        try:
-            file_path = output.split("(")[0]
-            if file_path != self.current_frame_file:
-                self.current_frame_file = file_path
-        except BaseException:
-            pass
+        workdir = f"{environment.working_dir}/"
+        sep = "> "
+        file_path = None
+        for line in output.splitlines():
+            # find the line that starts with "> "
+            if line.startswith(sep):
+                # extract the file path from the line,
+                # remove the leading "> ", the trailing "(line_number)<module>()", and working_dir
+                # constants.py(6)<module>()
+                # -> ACTION_TO_INDEX = {
+                file_path = line[len(sep) :].split("(")[0].replace(workdir, "")
+                break
+        if self.current_frame_file != file_path:
+            self.current_frame_file = file_path
+        return file_path

--- a/debug_gym/gym/tools/pdb.py
+++ b/debug_gym/gym/tools/pdb.py
@@ -181,12 +181,11 @@ class PDBTool(EnvironmentTool):
         # into self.last_eval_output, and remove them from the output
         if "The program exited via sys.exit()." in output:
             # end index is the last occurrence of the program exited (from the \n after)
-            end_index = (
-                output.find("\n", output.rfind("The program exited via sys.exit()."))
-                + 1
-            )
+            start_index = output.rfind("The program exited via sys.exit().")
+            end_index = output.find("\n", start_index) + 1
             output = (
-                "Reached the end of the file. Restarting the debugging session.\n"
+                output[:start_index]
+                + "\nReached the end of the program. Restarting the debugging session.\n"
                 + output[end_index:]
             )
         obs = "\n".join([_warning, output]).strip() + "\n"

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -265,7 +265,6 @@ def test_step(
     mock_pdb_tool.return_value = observation
     mock_pdb_tool.rewrite_success = True
     mock_pdb_tool.current_frame_file = "file.py"
-    mock_pdb_tool.pdb_obs = "PDB started"
     mock_get_tool.return_value = None
     mock_display_files.return_value = "file list"
 
@@ -315,7 +314,6 @@ def test_reset(
 ):
     mock_pdb_tool = MagicMock()
     mock_pdb_tool.start_pseudo_terminal.return_value = None
-    mock_pdb_tool.pdb_obs = "PDB started"
     mock_get_tool.return_value = mock_pdb_tool
     infos = env.reset()
 

--- a/tests/gym/tools/test_pdb.py
+++ b/tests/gym/tools/test_pdb.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -435,12 +436,18 @@ def test_use_breakpoints_and_clear(tmp_path, setup_pdb_repo_env):
     env.all_files = ["file1.py"]
     pdb_tool.current_frame_file = "file1.py"
     obs = pdb_tool.use(env, "b").observation
+    # clean up the pytest path to not depend on the environment
+    obs = re.sub(
+        r"Current frame:\n.*pytest/__main__\.py",
+        "Current frame:\n.../pytest/__main__.py",
+        obs,
+    )
     assert obs == (
         "Breakpoints:\n"
         "line 1 in file1.py\n"
         "\n"
         "Current frame:\n"
-        "/home/matpereira/miniconda3/envs/Froggy-terminal/lib/python3.12/site-packages/pytest/__main__.py\n"
+        ".../pytest/__main__.py\n"
         "\n"
         "Context around the current frame:\n"
         '1  ->\t"""The pytest entry point."""\r\n'
@@ -454,12 +461,19 @@ def test_use_breakpoints_and_clear(tmp_path, setup_pdb_repo_env):
         "  9  \t    raise SystemExit(pytest.console_main())\r\n"
         "[EOF]\n"
     )
+
     obs2 = pdb_tool.use(env, "cl").observation
+    # clean up the pytest path to not depend on the environment
+    obs2 = re.sub(
+        r"Current frame:\n.*pytest/__main__\.py",
+        "Current frame:\n.../pytest/__main__.py",
+        obs2,
+    )
     assert obs2 == (
         "All breakpoints have been cleared.\n"
         "\n"
         "Current frame:\n"
-        "/home/matpereira/miniconda3/envs/Froggy-terminal/lib/python3.12/site-packages/pytest/__main__.py\n"
+        ".../pytest/__main__.py\n"
         "\n"
         "Context around the current frame:\n"
         '1  ->\t"""The pytest entry point."""\r\n'

--- a/tests/gym/tools/test_pdb.py
+++ b/tests/gym/tools/test_pdb.py
@@ -77,10 +77,13 @@ def test_pdb_use(tmp_path, setup_test_repo):
     assert """The pytest entry point.""" in output
     assert "(Pdb)" not in output
     output = pdb.use(environment, command="c").observation
-    assert "1 failed, 1 passed" in pdb.pdb_obs
-    assert "test_fail.py::test_fail FAILED" in pdb.pdb_obs
-    assert "test_pass.py::test_pass PASSED" in pdb.pdb_obs
-    assert "Reached the end of the file. Restarting the debugging session." in output
+    assert "1 failed, 1 passed" in output
+    assert "test_fail.py::test_fail FAILED" in output
+    assert "test_pass.py::test_pass PASSED" in output
+    assert "Reached the end of the program. Restarting the debugging session." in output
+    assert "pytest/__main__.py" in output
+    assert '-> """The pytest entry point."""' in output
+    assert 'Context around the current frame:\n1  ->	"""The pytest entry point.""""'
     assert "(Pdb)" not in output
 
 
@@ -152,10 +155,13 @@ def test_pdb_use_default_environment_entrypoint(tmp_path, setup_test_repo):
     assert "(Pdb)" not in output
 
     output = pdb.use(environment, command="c").observation
-    assert "1 failed, 1 passed" in pdb.pdb_obs
-    assert "test_fail.py::test_fail" in pdb.pdb_obs
-    assert "test_pass.py::test_pass" not in pdb.pdb_obs
-    assert "Reached the end of the file. Restarting the debugging session." in output
+    assert "1 failed, 1 passed" in output
+    assert "test_fail.py::test_fail" in output
+    assert "test_pass.py::test_pass" not in output
+    assert "Reached the end of the program. Restarting the debugging session." in output
+    assert "pytest/__main__.py" in output
+    assert '-> """The pytest entry point."""' in output
+    assert 'Context around the current frame:\n1  ->	"""The pytest entry point.""""'
     assert "(Pdb)" not in output
 
 
@@ -182,10 +188,13 @@ def test_pdb_use_docker_terminal(tmp_path, setup_test_repo):
     assert "(Pdb)" not in output
 
     output = pdb.use(environment, command="c").observation
-    assert "1 failed, 1 passed" in pdb.pdb_obs
-    assert "test_fail.py::test_fail FAILED" in pdb.pdb_obs
-    assert "test_pass.py::test_pass PASSED" in pdb.pdb_obs
-    assert "Reached the end of the file. Restarting the debugging session." in output
+    assert "1 failed, 1 passed" in output
+    assert "test_fail.py::test_fail FAILED" in output
+    assert "test_pass.py::test_pass PASSED" in output
+    assert "Reached the end of the program. Restarting the debugging session." in output
+    assert "pytest/__main__.py" in output
+    assert '-> """The pytest entry point."""' in output
+    assert 'Context around the current frame:\n1  ->	"""The pytest entry point.""""'
     assert "(Pdb)" not in output
 
 

--- a/tests/gym/tools/test_pdb.py
+++ b/tests/gym/tools/test_pdb.py
@@ -191,7 +191,6 @@ def test_pdb_use_docker_terminal(tmp_path, setup_test_repo):
 
 def test_initialization():
     pdb_tool = PDBTool()
-    assert pdb_tool.pdb_obs == ""
     assert pdb_tool.current_frame_file is None
     assert pdb_tool._session is None
 
@@ -357,12 +356,11 @@ def test_close_pdb_start_and_close_session(tmp_path, setup_pdb_repo_env):
 
 def test_deepcopy_sets_session_none(tmp_path, setup_pdb_repo_env):
     pdb_tool, _ = setup_pdb_repo_env(tmp_path)
-    pdb_tool.pdb_obs = "obs"
-    pdb_tool.current_frame_file = "file1.py"
+    assert pdb_tool.current_frame_file.endswith("pytest/__main__.py")
     tool_copy = copy.deepcopy(pdb_tool)
     assert tool_copy._session is None
-    assert tool_copy.pdb_obs == "obs"
-    assert tool_copy.current_frame_file == "file1.py"
+    assert tool_copy.current_frame_file is None
+    assert pdb_tool.current_frame_file.endswith("pytest/__main__.py")
 
 
 def test_start_pdb_restores_breakpoints(tmp_path, setup_pdb_repo_env):


### PR DESCRIPTION
This pull request refactors the `PDBTool` class in `debug_gym` to improve its handling of the current frame file, remove unused attributes, and enhance the clarity of output during debugging sessions. It also updates the corresponding test cases to reflect these changes. Below are the most important changes grouped by theme:

### Refactoring and Cleanup in `PDBTool`:

* Removed the unused `pdb_obs` attribute from the `PDBTool` class, simplifying its state management. (`debug_gym/gym/tools/pdb.py`, [[1]](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L35) [[2]](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L163-R206) [[3]](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L256) [[4]](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L275)
* Introduced a new method `set_current_frame_file` to replace `get_current_frame_file`, improving the clarity and functionality of updating the current frame file. (`debug_gym/gym/tools/pdb.py`, [debug_gym/gym/tools/pdb.pyL339-R367](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L339-R367))
* Updated the `__deepcopy__` method to explicitly exclude non-serializable attributes like `_session` and reset `current_frame_file` to `None`. (`debug_gym/gym/tools/pdb.py`, [debug_gym/gym/tools/pdb.pyR44-R50](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100R44-R50))

### Improved Debugging Output:

* Enhanced the `use` method to provide more detailed context about the current frame and surrounding lines when running debugging commands. (`debug_gym/gym/tools/pdb.py`, [debug_gym/gym/tools/pdb.pyL163-R206](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L163-R206))
* Updated the output of breakpoint-related commands to include a clearer representation of breakpoints and the current frame. (`debug_gym/gym/tools/pdb.py`, [debug_gym/gym/tools/pdb.pyL133-R141](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L133-R141), F2ee441eL443R435)

### Test Updates:

* Removed references to the obsolete `pdb_obs` attribute in multiple test cases. (`tests/gym/envs/test_env.py`, [[1]](diffhunk://#diff-23de2a1adcfb974ec64b19d2f73ab9b35069d7f9c23da87a015fd0a6be1a5e4bL268) [[2]](diffhunk://#diff-23de2a1adcfb974ec64b19d2f73ab9b35069d7f9c23da87a015fd0a6be1a5e4bL318); `tests/gym/tools/test_pdb.py`, [[3]](diffhunk://#diff-d24e085abb201b4ea6423857f7c2a8b10a1e659c911c7af8313af63148b11aaeL54) [[4]](diffhunk://#diff-d24e085abb201b4ea6423857f7c2a8b10a1e659c911c7af8313af63148b11aaeL81-R86) [[5]](diffhunk://#diff-d24e085abb201b4ea6423857f7c2a8b10a1e659c911c7af8313af63148b11aaeL375-R372)
* Updated assertions in test cases to validate the new output format, including context around the current frame and improved breakpoint handling. (`tests/gym/tools/test_pdb.py`, [[1]](diffhunk://#diff-d24e085abb201b4ea6423857f7c2a8b10a1e659c911c7af8313af63148b11aaeL446-R475) [[2]](diffhunk://#diff-d24e085abb201b4ea6423857f7c2a8b10a1e659c911c7af8313af63148b11aaeL189-L198) [[3]](diffhunk://#diff-d24e085abb201b4ea6423857f7c2a8b10a1e659c911c7af8313af63148b11aaeL159-R164)

These changes collectively improve the maintainability, functionality, and user experience of the `PDBTool` class and its associated tests.