### PR TITLE
Fix Aider ignore patterns and add tests for path resolution and ignored/read-only files

### DIFF
--- a/debug_gym/gym/envs/aider.py
+++ b/debug_gym/gym/envs/aider.py
@@ -66,7 +66,7 @@ class AiderBenchmarkEnv(RepoEnv):
             utils.create_ignore_file(
                 directory / ".debugignore",
                 patterns=[
-                    ".*/",
+                    ".*/*",  # Aider is single-file, so ignore nested directories.
                     "__pycache__/",
                     "*.pyc",
                     # "*.md",

--- a/tests/gym/envs/test_aider.py
+++ b/tests/gym/envs/test_aider.py
@@ -92,3 +92,35 @@ def test_step(mock_step, aider_env, env_info):
 def test_load_dataset(mock_listdir, mock_exists, mock_run, aider_env):
     aider_env.load_dataset()
     assert mock_run.called
+
+
+def test_resolve_path():
+    env = AiderBenchmarkEnv()
+    env.reset(options={"task_name": "hangman"})
+    path = env.resolve_path(env.working_dir, raises=True)
+    assert path == env.working_dir
+    assert env.resolve_path("hangman.py", raises=True) == env.working_dir / "hangman.py"
+    with pytest.raises(FileNotFoundError):
+        env.resolve_path("nested/file.py", raises=True)
+
+
+def test_ignored_files():
+    env = AiderBenchmarkEnv()
+    env.reset(options={"task_name": "hangman"})
+    assert env.has_file("hangman_test.py")
+    assert env.has_file("hangman.py")
+    assert not env.has_file(".gitignore")
+    assert not env.has_file(".debugignore")
+    assert not env.has_file(".debugreadonly")
+    assert not env.has_file("nested/file.py")
+
+
+def test_is_editable_files():
+    env = AiderBenchmarkEnv()
+    env.reset(options={"task_name": "hangman"})
+    assert env.is_editable("hangman.py")
+    assert not env.is_editable("hangman_test.py")
+    with pytest.raises(FileNotFoundError):
+        assert not env.is_editable("nested/file.py")
+    with pytest.raises(FileNotFoundError):
+        assert not env.is_editable(".debugignore")

--- a/tests/gym/envs/test_aider.py
+++ b/tests/gym/envs/test_aider.py
@@ -95,13 +95,12 @@ def test_load_dataset(mock_listdir, mock_exists, mock_run, aider_env):
 
 
 @pytest.fixture
-@patch("pathlib.Path.home")
-def env(mock_home, tmp_path):
-    mock_home.return_value = tmp_path
-    aider_path = AiderBenchmarkEnv.REPO_PATH
-    aider_path.mkdir(exist_ok=True)
-    repo_path = aider_path / "hangman"
-    repo_path.mkdir(exist_ok=True)
+def env(tmp_path):
+    aider_path = tmp_path / ".cache" / "debug_gym" / "exercism"
+    aider_path.mkdir(parents=True, exist_ok=True)
+    AiderBenchmarkEnv.REPO_PATH = aider_path
+    repo_path = aider_path / "exercises" / "practice" / "hangman"
+    repo_path.mkdir(parents=True, exist_ok=True)
     (repo_path / "hangman.py").write_text("return 'Hello, Hangman!'")
     (repo_path / "hangman_test.py").write_text(
         "import hangman\n"

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -541,6 +541,9 @@ def test_resolve_path(tmp_path):
     env = RepoEnv(path=tmp_path)
     abs_path = (env.working_dir / "file.txt").resolve()
     (abs_path).touch()
+    # env.working_dir itself
+    path_from_env = env.resolve_path(str(env.working_dir), raises=True)
+    assert path_from_env == env.working_dir.resolve()
     # relative path
     path_from_env = env.resolve_path("file.txt")
     assert path_from_env == abs_path


### PR DESCRIPTION
Updated Aider `.debugignore` to ignore nested directories, but not the `working_dir` itself (`".*/"` -> `".*/*"`).