### PR TITLE
Fix issue resolving `env.working_dir`

### DIFF
--- a/debug_gym/gym/envs/aider.py
+++ b/debug_gym/gym/envs/aider.py
@@ -66,7 +66,7 @@ class AiderBenchmarkEnv(RepoEnv):
             utils.create_ignore_file(
                 directory / ".debugignore",
                 patterns=[
-                    ".*/*",  # Aider is single-file, so ignore nested directories.
+                    ".?*",  # Ignore hidden files and directories but not current dir "."
                     "__pycache__/",
                     "*.pyc",
                     # "*.md",

--- a/debug_gym/gym/envs/aider.py
+++ b/debug_gym/gym/envs/aider.py
@@ -66,7 +66,7 @@ class AiderBenchmarkEnv(RepoEnv):
             utils.create_ignore_file(
                 directory / ".debugignore",
                 patterns=[
-                    ".*/",
+                    ".*/*",  # Aider is single-file, so ignore nested directories.
                     "__pycache__/",
                     "*.pyc",
                     # "*.md",

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -370,10 +370,14 @@ class RepoEnv(TooledEnv):
         abs_filepath = Path(filepath)
         if not abs_filepath.is_absolute():
             abs_filepath = (Path(self.working_dir) / abs_filepath).resolve()
-        if raises and not (
-            abs_filepath.is_relative_to(self.working_dir)
-            and abs_filepath.exists()
-            and not self._is_ignored_func(abs_filepath)
+        if (
+            raises
+            and abs_filepath != self.working_dir
+            and not (
+                abs_filepath.is_relative_to(self.working_dir)
+                and abs_filepath.exists()
+                and not self._is_ignored_func(abs_filepath)
+            )
         ):
             # raises error with original path
             raise FileNotFoundError(

--- a/debug_gym/gym/envs/swe_bench.py
+++ b/debug_gym/gym/envs/swe_bench.py
@@ -323,7 +323,7 @@ class SWEBenchEnv(RepoEnv):
     @property
     def ignore_files(self):
         return [
-            ".*/",
+            ".?*",  # Ignore hidden files and directories but not current dir "."
             # ".pytest_cache/",
             # "*test*.py",
             # "*.pyc",

--- a/tests/gym/envs/test_aider.py
+++ b/tests/gym/envs/test_aider.py
@@ -1,97 +1,8 @@
-from unittest.mock import MagicMock, mock_open, patch
-
 import pytest
 
-from debug_gym.gym.entities import Observation
 from debug_gym.gym.envs import AiderBenchmarkEnv
-from debug_gym.gym.envs.env import EnvInfo
-
-
-@pytest.fixture
-def env_info():
-    return EnvInfo(
-        step_observation=Observation("tool", "obs"),
-        all_observations=[],
-        eval_observation=Observation("env", "eval_observation"),
-        dir_tree="dir_tree",
-        current_breakpoints="current_breakpoints",
-        action="action",
-        instructions={},
-        score=5,
-        max_score=10,
-        done=False,
-        rewrite_counter=0,
-        tools=[],
-    )
-
-
-@pytest.fixture
-@patch("subprocess.run")
-@patch("os.path.exists", return_value=False)
-@patch("pathlib.Path.iterdir")
-@patch("pathlib.Path.read_text", return_value="Test instructions")
-@patch("os.listdir", return_value=[".gitignore"])
-@patch("builtins.open", new_callable=mock_open)
-def aider_env(
-    mock_open, mock_listdir, mock_read_text, mock_iterdir, mock_exists, mock_run
-):
-    # Mock the directories
-    mock_dir = MagicMock()
-    mock_dir.is_dir.return_value = True
-    mock_dir.name = "test_task"
-    mock_iterdir.return_value = [mock_dir]
-
-    # Initialize the AiderBenchmarkEnv
-    env = AiderBenchmarkEnv()
-    return env
-
-
-def test_instructions(aider_env):
-    aider_env.current_sample = {"instructions": "Test instructions"}
-    expected_instructions = {"Problem description": "Test instructions"}
-    assert aider_env.instructions == expected_instructions
-
-
-@patch("debug_gym.gym.envs.RepoEnv.reset")
-@patch("debug_gym.gym.envs.AiderBenchmarkEnv.setup_workspace")
-def test_reset(
-    mock_setup_workspace,
-    repo_env,
-    aider_env,
-    env_info,
-):
-    test_task = {
-        "test_task": {
-            "base_directory": "test_directory",
-            "instructions": "Test instructions",
-            "filename": "test_task.py",
-        }
-    }
-    repo_env.return_value = env_info
-    aider_env.dataset = test_task
-    options = {"task_name": "test_task"}
-    infos = aider_env.reset(options=options)
-    assert aider_env.current_sample == test_task["test_task"]
-    assert infos.step_observation == Observation("tool", "obs")
-    assert infos.max_score == 10
-    assert infos.score == 5
-
-
-# TODO: Add proper test, mocking repoenv.step doesn't test anything
-@patch("debug_gym.gym.envs.RepoEnv.step")
-def test_step(mock_step, aider_env, env_info):
-    mock_step.return_value = env_info
-    infos = aider_env.step("action")
-    assert infos.step_observation == Observation("tool", "obs")
-    assert infos.score == 5
-
-
-@patch("subprocess.run")
-@patch("os.path.exists", return_value=False)
-@patch("os.listdir", return_value=[".gitignore"])
-def test_load_dataset(mock_listdir, mock_exists, mock_run, aider_env):
-    aider_env.load_dataset()
-    assert mock_run.called
+from debug_gym.gym.tools.tool import ToolCall
+from debug_gym.gym.tools.toolbox import Toolbox
 
 
 @pytest.fixture
@@ -99,31 +10,36 @@ def env(tmp_path):
     aider_path = tmp_path / ".cache" / "debug_gym" / "exercism"
     aider_path.mkdir(parents=True, exist_ok=True)
     AiderBenchmarkEnv.REPO_PATH = aider_path
-    repo_path = aider_path / "exercises" / "practice" / "hangman"
+    repo_path = aider_path / "exercises" / "practice" / "clock"
     repo_path.mkdir(parents=True, exist_ok=True)
-    (repo_path / "hangman.py").write_text("return 'Hello, Hangman!'")
-    (repo_path / "hangman_test.py").write_text(
-        "import hangman\n"
-        "\n"
-        "def test_hangman():\n"
-        "    assert hangman() == 'Hello, Hangman!'"
+    (repo_path / "clock.py").write_text(
+        "def current_time():  # returns a message with the current time\n"
+        "    return 'It is 10:00 a.m.'"
     )
+    (repo_path / "clock_test.py").write_text(
+        "import clock\n"
+        "\n"
+        "def test_clock():\n"
+        "    assert clock.current_time() == 'It is 12:00 a.m.'"
+    )
+    (repo_path / ".docs").mkdir(parents=True, exist_ok=True)
+    (repo_path / ".docs" / "instructions.md").write_text("What time is it?")
     env = AiderBenchmarkEnv()
-    env.reset(options={"task_name": "hangman"})
+    env.reset(options={"task_name": "clock"})
     return env
 
 
 def test_resolve_path(env):
     path = env.resolve_path(env.working_dir, raises=True)
     assert path == env.working_dir
-    assert env.resolve_path("hangman.py", raises=True) == env.working_dir / "hangman.py"
+    assert env.resolve_path("clock.py", raises=True) == env.working_dir / "clock.py"
     with pytest.raises(FileNotFoundError):
         env.resolve_path("nested/file.py", raises=True)
 
 
 def test_ignored_files(env):
-    assert env.has_file("hangman_test.py")
-    assert env.has_file("hangman.py")
+    assert env.has_file("clock_test.py")
+    assert env.has_file("clock.py")
     assert not env.has_file(".gitignore")
     assert not env.has_file(".debugignore")
     assert not env.has_file(".debugreadonly")
@@ -131,9 +47,47 @@ def test_ignored_files(env):
 
 
 def test_is_editable_files(env):
-    assert env.is_editable("hangman.py")
-    assert not env.is_editable("hangman_test.py")
+    assert env.is_editable("clock.py")
+    assert not env.is_editable("clock_test.py")
     with pytest.raises(FileNotFoundError):
         assert not env.is_editable("nested/file.py")
     with pytest.raises(FileNotFoundError):
         assert not env.is_editable(".debugignore")
+
+
+def test_steps(env):
+    eval_tool = Toolbox.get_tool("eval")
+    env.add_tool(eval_tool)
+    eval_call = ToolCall(id="eval_id", name="eval", arguments={})
+    infos = env.step(eval_call)
+    assert infos.step_observation.source == "eval"
+    assert "clock_test.py F" in infos.eval_observation.observation
+    assert "1 failed" in infos.eval_observation.observation
+    assert infos.score == 0
+    rewrite_tool = Toolbox.get_tool("rewrite")
+    env.add_tool(rewrite_tool)
+    infos = env.step(
+        ToolCall(
+            id="rewrite_id",
+            name="rewrite",
+            arguments={
+                "path": "clock.py",
+                "start": 2,
+                "new_code": "    return 'It is 12:00 a.m.'",
+            },
+        )
+    )
+    assert infos.step_observation.source == "rewrite"
+    assert infos.step_observation.observation.startswith(
+        "The file `clock.py` has been updated successfully."
+    )
+    assert infos.score == 1
+    infos = env.step(eval_call)
+    assert infos.step_observation.source == "eval"
+    assert "clock_test.py ." in infos.eval_observation.observation
+    assert "1 passed" in infos.eval_observation.observation
+    assert infos.score == 1
+
+
+def test_instructions(env):
+    assert env.instructions == {"Problem description": "What time is it?"}

--- a/tests/gym/envs/test_aider.py
+++ b/tests/gym/envs/test_aider.py
@@ -92,3 +92,35 @@ def test_step(mock_step, aider_env, env_info):
 def test_load_dataset(mock_listdir, mock_exists, mock_run, aider_env):
     aider_env.load_dataset()
     assert mock_run.called
+
+
+def test_resolve_path():
+    env = AiderBenchmarkEnv()
+    env.reset(options={"task_name": "hangman"})
+    path = env.resolve_path(env.working_dir, raises=True)
+    assert path == env.working_dir
+    assert env.resolve_path("hangman.py", raises=True) == env.working_dir / "hangman.py"
+    with pytest.raises(FileNotFoundError):
+        env.resolve_path("nested/file.py", raises=True)
+
+
+def test_ignored_files():
+    env = AiderBenchmarkEnv()
+    env.reset(options={"task_name": "hangman"})
+    assert env.has_file("hangman_test.py")
+    assert env.has_file("hangman.py")
+    assert not env.has_file(".gitignore")
+    assert not env.has_file(".debugignore")
+    assert not env.has_file(".debugreadonly")
+    assert not env.has_file("nested/file.py")
+
+
+def test_is_editable_files():
+    env = AiderBenchmarkEnv()
+    env.reset(options={"task_name": "hangman"})
+    assert env.is_editable("hangman.py")
+    assert not env.is_editable("hangman_test.py")
+    with pytest.raises(FileNotFoundError):
+        assert not env.is_editable("nested/file.py")
+    with pytest.raises(FileNotFoundError):
+        assert not env.is_editable(".debugignore")

--- a/tests/gym/envs/test_aider.py
+++ b/tests/gym/envs/test_aider.py
@@ -95,13 +95,12 @@ def test_load_dataset(mock_listdir, mock_exists, mock_run, aider_env):
 
 
 @pytest.fixture
-@patch("pathlib.Path.home")
-def env(mock_home, tmp_path):
-    mock_home.return_value = tmp_path
-    aider_path = AiderBenchmarkEnv.REPO_PATH
-    aider_path.mkdir(exist_ok=True)
-    repo_path = aider_path / "hangman"
-    repo_path.mkdir(exist_ok=True)
+def env(tmp_path):
+    aider_path = tmp_path / ".cache" / "debug_gym" / "exercism"
+    aider_path.mkdir(parents=True, exist_ok=True)
+    AiderBenchmarkEnv.REPO_PATH = aider_path
+    repo_path = aider_path / "exercises" / "practice" / "hangman"
+    repo_path.mkdir(parents=True, exist_ok=True)
     (repo_path / "hangman.py").write_text("return 'Hello, Hangman!'")
     (repo_path / "hangman_test.py").write_text(
         "import hangman\n"

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -541,6 +541,9 @@ def test_resolve_path(tmp_path):
     env = RepoEnv(path=tmp_path)
     abs_path = (env.working_dir / "file.txt").resolve()
     (abs_path).touch()
+    # env.working_dir itself
+    path_from_env = env.resolve_path(str(env.working_dir), raises=True)
+    assert path_from_env == env.working_dir.resolve()
     # relative path
     path_from_env = env.resolve_path("file.txt")
     assert path_from_env == abs_path


### PR DESCRIPTION
* Never raise exceptions for the working directory in `env.resolve_path` regardless of ignore patterns.
* Change `.debugignore` to use `.?*` (ignore every hidden file and directory except the current directory ".")
* Add tests and test Aider with fewer mocks