### PR TITLE
Set default `RepoEnv.dir_tree_depth` to 1

### DIFF
--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -155,7 +155,7 @@ class RepoEnv(TooledEnv):
         readonly_patterns: list[str] | None = None,
         auto_eval_on_rewrite: bool = True,
         run_timeout: int | None = None,
-        dir_tree_depth: int | None = None,
+        dir_tree_depth: int = 1,
         persistent_breakpoints: bool = True,
         auto_list: bool = True,
         terminal: Terminal | None = None,

--- a/debug_gym/gym/tools/listdir.py
+++ b/debug_gym/gym/tools/listdir.py
@@ -1,5 +1,3 @@
-from os.path import join as pjoin
-
 from debug_gym.gym.entities import Observation
 from debug_gym.gym.tools.tool import EnvironmentTool
 from debug_gym.gym.tools.toolbox import Toolbox

--- a/tests/gym/envs/test_swe_bench.py
+++ b/tests/gym/envs/test_swe_bench.py
@@ -52,28 +52,6 @@ def get_swe_env(build_swe_env_once):
 
 
 @if_docker_running
-def test_load_dataset(tmp_path, get_swe_env):
-    working_dir = str(tmp_path)
-    swe_env = get_swe_env(working_dir)
-    assert swe_env.dataset_id == "princeton-nlp/SWE-bench_Verified"
-    # check if the dataset contains features that SWEBenchEnv expects
-    assert list(swe_env.ds.features.keys()) == [
-        "repo",
-        "instance_id",
-        "base_commit",
-        "patch",  # not required
-        "test_patch",
-        "problem_statement",
-        "hints_text",  # not required
-        "created_at",  # not required
-        "version",  # not required
-        "FAIL_TO_PASS",
-        "PASS_TO_PASS",
-        "environment_setup_commit",  # not required
-    ]
-
-
-@if_docker_running
 def test_clone_repo(tmp_path, get_swe_env):
     working_dir = str(tmp_path)
     swe_env = get_swe_env(working_dir)
@@ -228,7 +206,6 @@ def test_run_post_install(tmp_path, install_configs_mock, get_swe_env):
 def test_load_dataset(tmp_path, get_swe_env):
     working_dir = str(tmp_path)
     swe_env = get_swe_env(working_dir)
-    swe_env.load_dataset()
     assert swe_env.dataset_id == "princeton-nlp/SWE-bench_Verified"
     task_name = "astropy__astropy-14096"
     assert task_name in swe_env.dataset.keys()
@@ -254,7 +231,6 @@ def test_setup_task_info(tmp_path, get_swe_env):
     working_dir = str(tmp_path)
     swe_env = get_swe_env(working_dir)
     task_name = "astropy__astropy-14096"
-    swe_env.load_dataset()
     swe_env.setup_task_info(task_name)
     assert swe_env.task_name == task_name
     assert swe_env.ds_row["repo"] == "astropy/astropy"
@@ -268,7 +244,6 @@ def test_setup_local_repo(tmp_path, get_swe_env):
     working_dir = str(tmp_path)
     swe_env = get_swe_env(working_dir)
     task_name = "astropy__astropy-14096"
-    swe_env.load_dataset()
     swe_env.setup_task_info(task_name)
     swe_env.setup_local_repo()
     git_commit = subprocess.run(


### PR DESCRIPTION
Set `RepoEnv.dir_tree_depth =  1` by default.
This does not change any behavior compared to previous experiments since we already set the `dir_tree_depth` in the config yaml `env_kwargs`