### PR TITLE
replace unescape by filtering non-utf8 chars in system prompts

### DIFF
--- a/debug_gym/agents/base_agent.py
+++ b/debug_gym/agents/base_agent.py
@@ -10,7 +10,7 @@ import numpy as np
 from debug_gym.agents.history_tracker import HistoryTracker, build_history_prompt
 from debug_gym.agents.utils import trim
 from debug_gym.gym.envs.env import RepoEnv
-from debug_gym.gym.utils import unescape
+from debug_gym.gym.utils import filter_non_utf8
 from debug_gym.llms.base import LLM
 from debug_gym.logger import DebugGymLogger
 
@@ -74,7 +74,7 @@ class BaseAgent:
 
     def build_system_prompt(self, info):
         def calc_tokens_left(system_prompt: dict):
-            system_prompt = unescape(
+            system_prompt = filter_non_utf8(
                 json.dumps(system_prompt, indent=2, sort_keys=False)
             )
             return self.llm.context_length - self.llm.count_tokens(system_prompt)
@@ -129,7 +129,7 @@ class BaseAgent:
         if len(shortcut_features) > 0:
             system_prompt["Shortcut features"] = shortcut_features
 
-        system_prompt = unescape(json.dumps(system_prompt, indent=2, sort_keys=False))
+        system_prompt = filter_non_utf8(json.dumps(system_prompt, indent=2, sort_keys=False))
         messages = [
             {
                 "role": "system",

--- a/debug_gym/agents/base_agent.py
+++ b/debug_gym/agents/base_agent.py
@@ -129,7 +129,9 @@ class BaseAgent:
         if len(shortcut_features) > 0:
             system_prompt["Shortcut features"] = shortcut_features
 
-        system_prompt = filter_non_utf8(json.dumps(system_prompt, indent=2, sort_keys=False))
+        system_prompt = filter_non_utf8(
+            json.dumps(system_prompt, indent=2, sort_keys=False)
+        )
         messages = [
             {
                 "role": "system",

--- a/debug_gym/gym/utils.py
+++ b/debug_gym/gym/utils.py
@@ -13,6 +13,13 @@ def clean_code(code):
     return "\n".join(line.rstrip() for line in code_line)
 
 
+def filter_non_utf8(text):
+    """Filter out non-UTF-8 characters from text."""
+    if isinstance(text, str):
+        return text.encode('utf-8', errors='ignore').decode('utf-8')
+    return text
+
+
 def unescape(s):
     try:
         # First, try the normal unescape

--- a/debug_gym/gym/utils.py
+++ b/debug_gym/gym/utils.py
@@ -16,7 +16,7 @@ def clean_code(code):
 def filter_non_utf8(text):
     """Filter out non-UTF-8 characters from text."""
     if isinstance(text, str):
-        return text.encode('utf-8', errors='ignore').decode('utf-8')
+        return text.encode("utf-8", errors="ignore").decode("utf-8")
     return text
 
 

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -1,5 +1,6 @@
 from debug_gym.gym.envs.env import EnvInfo
 from debug_gym.gym.tools.tool import EnvironmentTool, ToolCall
+from debug_gym.gym.utils import filter_non_utf8
 from debug_gym.llms.base import LLM, LLMResponse, retry_on_rate_limit
 from debug_gym.llms.constants import LLM_API_KEY_PLACEHOLDER
 
@@ -127,7 +128,9 @@ class AnthropicLLM(LLM):
                     {
                         "type": "tool_result",
                         "tool_use_id": history_info.action.id,  # 'toolu_01SdR84CsnTKRpdH4zwFjvGj'
-                        "content": f"{history_info.step_observation.observation}",  # 'Viewing `hangman_test.py`. The file is read-only, it is not editable.'
+                        "content": filter_non_utf8(
+                            f"{history_info.step_observation.observation}"
+                        ),  # 'Viewing `hangman_test.py`. The file is read-only, it is not editable.'
                     }
                 ],
             },

--- a/debug_gym/llms/human.py
+++ b/debug_gym/llms/human.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from debug_gym.gym.envs.env import EnvInfo
 from debug_gym.gym.tools.tool import EnvironmentTool, ToolCall
+from debug_gym.gym.utils import filter_non_utf8
 from debug_gym.llms.base import LLM, LLMResponse
 from debug_gym.llms.utils import print_messages
 from debug_gym.logger import DebugGymLogger
@@ -513,7 +514,9 @@ class Human(LLM):
                     {
                         "type": "tool_result",
                         "tool_use_id": history_info.action.id,
-                        "content": f"{history_info.step_observation.observation}",
+                        "content": filter_non_utf8(
+                            f"{history_info.step_observation.observation}"
+                        ),
                     }
                 ],
             },

--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -8,6 +8,7 @@ from transformers import AutoTokenizer
 
 from debug_gym.gym.envs.env import EnvInfo
 from debug_gym.gym.tools.tool import EnvironmentTool, ToolCall
+from debug_gym.gym.utils import filter_non_utf8
 from debug_gym.llms.base import (
     LLM,
     ContextLengthExceededError,
@@ -166,7 +167,9 @@ class OpenAILLM(LLM):
                 "role": "tool",
                 "tool_call_id": history_info.action.id,
                 "name": history_info.action.name,
-                "content": f"{history_info.step_observation.observation}",
+                "content": filter_non_utf8(
+                    f"{history_info.step_observation.observation}"
+                ),
             },
         ]
         return _messages


### PR DESCRIPTION
Now the system prompt content should be able to be parsed by `json.loads()` into a valid JSON object.