### PR TITLE
Improve Retry

### DIFF
--- a/debug_gym/gym/tools/view.py
+++ b/debug_gym/gym/tools/view.py
@@ -15,7 +15,7 @@ class ViewTool(EnvironmentTool):
         """view(path="src/main.py", start=514) to show the content of a file called 'main.py' in a subdirectory called 'src', starting from line 514 to the end of the file. The content will be annotated with line numbers and current breakpoints.""",
     ]
     description = (
-        "Specify a file path to set as current working file. The file path should be relative to the root directory of the repository."
+        "Specify a file path to view its content. The file path should be relative to the root directory of the repository."
         + "\nExamples (for demonstration purposes only, you need to adjust the tool calling format according to your specific syntax):\n"
         + "\n".join(examples)
     )

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -1,7 +1,12 @@
 from debug_gym.gym.envs.env import EnvInfo
 from debug_gym.gym.tools.tool import EnvironmentTool, ToolCall
 from debug_gym.gym.utils import filter_non_utf8
-from debug_gym.llms.base import LLM, LLMResponse, retry_on_rate_limit
+from debug_gym.llms.base import (
+    LLM,
+    ContextLengthExceededError,
+    LLMResponse,
+    retry_on_rate_limit,
+)
 from debug_gym.llms.constants import LLM_API_KEY_PLACEHOLDER
 
 

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -172,7 +172,7 @@ class AnthropicLLM(LLM):
         try:
             # https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview
             response = retry_on_exception(
-                self.client.messages.create, self.is_rate_limit_error
+                self.client.messages.create, self.need_to_be_retried
             )(
                 model=self.config.model,
                 system=system_prompt,

--- a/debug_gym/llms/base.py
+++ b/debug_gym/llms/base.py
@@ -24,13 +24,13 @@ from debug_gym.logger import DebugGymLogger
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
-def retry_on_rate_limit(
-    func, is_rate_limit_error_func, multiplier=1, max_wait=40, max_attempts=100
+def retry_on_exception(
+    func, exception_filter_func, multiplier=1, max_wait=40, max_attempts=100
 ):
-    """Executes a function with retry logic for rate limits. Never retries on KeyboardInterrupt.
+    """Executes a function with retry logic for certain exceptions. Never retries on KeyboardInterrupt.
     Args:
         func: The function to execute with retries
-        is_rate_limit_error_func: Function that checks if an exception is a rate limit error
+        exception_filter_func: Function that checks if an exception needs to be retried
         *args, **kwargs: Arguments to pass to the function
 
     Returns:
@@ -39,7 +39,7 @@ def retry_on_rate_limit(
     retry_function = retry(
         retry=(
             retry_if_not_exception_type(KeyboardInterrupt)
-            & retry_if_exception(is_rate_limit_error_func)
+            & retry_if_exception(exception_filter_func)
         ),
         wait=wait_random_exponential(multiplier=multiplier, max=max_wait),
         stop=stop_after_attempt(max_attempts),

--- a/debug_gym/llms/constants.py
+++ b/debug_gym/llms/constants.py
@@ -43,12 +43,23 @@ deepseek-r1-distill-qwen-32b:
   tokenizer: Qwen/Qwen2.5-32B
   endpoint: "{LLM_ENDPOINT_PLACEHOLDER}"
   api_key: "{LLM_API_KEY_PLACEHOLDER}"
-  tags: [DeepSeek-R1-Distill-Qwen-32B, H100]
+  tags: [DeepSeek-R1-Distill-Qwen-32B, vllm]
   system_prompt_support: false
   context_limit: 128
   reasoning_end_token: "</think>"
   generate_kwargs:
     temperature: 0.5
+
+qwen3-8b-vllm:
+  model: Qwen/Qwen3-8b
+  tokenizer: Qwen/Qwen3-8b
+  endpoint: "{LLM_ENDPOINT_PLACEHOLDER}"
+  api_key: "{LLM_API_KEY_PLACEHOLDER}"
+  tags: [qwen3-8b, vllm]
+  context_limit: 128
+  generate_kwargs:
+    temperature: 0.5
+    max_tokens: 8192
 
 claude-3.7:
   model: claude-3-7-sonnet-20250219

--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -187,7 +187,7 @@ class OpenAILLM(LLM):
         kwargs["max_tokens"] = kwargs.get("max_tokens", NOT_GIVEN)
         try:
             response = retry_on_exception(
-                self.client.chat.completions.create, self.is_rate_limit_error
+                self.client.chat.completions.create, self.need_to_be_retried
             )(
                 model=self.config.model,
                 messages=messages,

--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -71,6 +71,7 @@ class OpenAILLM(LLM):
             "openai.APIConnectionError",
             "openai.RateLimitError",
             "openai.PermissionDeniedError",
+            "openai.BadRequestError",
             # Add more as needed
         ]
         exception_full_name = (
@@ -92,6 +93,13 @@ class OpenAILLM(LLM):
             ):
                 is_error = False
                 logger = self.logger.warning
+        if (
+            exception_full_name == "openai.BadRequestError"
+            and len(self.config.tags) > 0
+            and "vllm" not in self.config.tags
+        ):
+            # only retry when a such error occurs on a model hosting on vllm
+            is_error = False
 
         logger(
             f"Error calling {self.model_name}: {exception_full_name!r} {


### PR DESCRIPTION
1. added `BadRequestError` to the list of errors that need to be retried (but only when running models on vLLM, which uses the OpenAI API). 
2. renamed the `is_rate_limit_error` by `need_to_be_retried` to better reflect the function's purpose, because not all exceptions we catch in the methods are rate limit errors.
3. Added an example with `max_tokens` to the llm config templates.
4. minor change in the `view` description to improve clarity and consistency in the tool's usage