### PR TITLE
Resolve path mismatch issue raised on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,12 @@ on:
 jobs:
   tests:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         language: [ "python" ]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ "python" ]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ debug_gym
 
 `debug_gym.llms` are the different LLM backends that can be used to instantiate agents. Currently, we support OpenAI, Azure OpenAI, and Anthropic.
 
+> [!WARNING]
+> `debug-gym` has limited support on non-Linux platforms. Interactive terminal sessions using PTY (pseudo-terminal) in Docker are not fully supported on macOS or Windows. As a result, the `pdb` tool (see [2.1. Environment and Tools](#21-environment-and-tools)) only works on Linux.
+
 ---
 
 #### 2.1. Environment and Tools

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -218,14 +218,11 @@ class RepoEnv(TooledEnv):
         self.path = Path(path)
 
         # Create a random temporary folder for storing a backup of the repo.
-<<<<<<< HEAD
         self.tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
         self.working_dir = Path(self.tempdir.name).resolve()
-=======
         self._tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
         self.working_dir = Path(self._tempdir.name).resolve()
 
->>>>>>> a06ee2902dfc3c15651bbda50dd535bb1280f53b
         # Make sure to cleanup that folder once done.
         atexit.register(self._tempdir.cleanup)
 

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -374,7 +374,7 @@ class RepoEnv(TooledEnv):
         """
         abs_filepath = Path(filepath)
         if not abs_filepath.is_absolute():
-            abs_filepath = (Path(self.working_dir) / abs_filepath).resolve()
+            abs_filepath = (Path(self.working_dir) / abs_filepath).absolute()
         if (
             raises
             and abs_filepath != self.working_dir

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -176,7 +176,7 @@ class RepoEnv(TooledEnv):
         self.logger = logger or DebugGymLogger("debug-gym")
         self.infos: EnvInfo | None = None
         self.rng = None
-        self.tempdir = None
+        self._tempdir = None
 
         self.setup_workspace(
             path=path,
@@ -218,10 +218,16 @@ class RepoEnv(TooledEnv):
         self.path = Path(path)
 
         # Create a random temporary folder for storing a backup of the repo.
+<<<<<<< HEAD
         self.tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
         self.working_dir = Path(self.tempdir.name).resolve()
+=======
+        self._tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
+        self.working_dir = Path(self._tempdir.name).resolve()
+
+>>>>>>> a06ee2902dfc3c15651bbda50dd535bb1280f53b
         # Make sure to cleanup that folder once done.
-        atexit.register(self.tempdir.cleanup)
+        atexit.register(self._tempdir.cleanup)
 
         self.logger.debug(f"Working directory: {self.working_dir}")
         shutil.copytree(self.path, self.working_dir, dirs_exist_ok=True, symlinks=True)
@@ -268,8 +274,8 @@ class RepoEnv(TooledEnv):
         return entrypoint
 
     def cleanup_workspace(self):
-        if self.tempdir:
-            self.tempdir.cleanup()
+        if self._tempdir:
+            self._tempdir.cleanup()
 
     @property
     def instructions(self) -> str:

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -218,8 +218,6 @@ class RepoEnv(TooledEnv):
         self.path = Path(path)
 
         # Create a random temporary folder for storing a backup of the repo.
-        self.tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
-        self.working_dir = Path(self.tempdir.name).resolve()
         self._tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
         self.working_dir = Path(self._tempdir.name).resolve()
 

--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -219,7 +219,7 @@ class RepoEnv(TooledEnv):
 
         # Create a random temporary folder for storing a backup of the repo.
         self.tempdir = tempfile.TemporaryDirectory(prefix="RepoEnv-")
-        self.working_dir = Path(self.tempdir.name)
+        self.working_dir = Path(self.tempdir.name).resolve()
         # Make sure to cleanup that folder once done.
         atexit.register(self.tempdir.cleanup)
 
@@ -374,7 +374,7 @@ class RepoEnv(TooledEnv):
         """
         abs_filepath = Path(filepath)
         if not abs_filepath.is_absolute():
-            abs_filepath = (Path(self.working_dir) / abs_filepath).absolute()
+            abs_filepath = (Path(self.working_dir) / abs_filepath).resolve()
         if (
             raises
             and abs_filepath != self.working_dir

--- a/debug_gym/gym/terminal.py
+++ b/debug_gym/gym/terminal.py
@@ -9,6 +9,7 @@ import tempfile
 import termios
 import time
 import uuid
+from pathlib import Path
 
 import docker
 
@@ -215,9 +216,9 @@ class Terminal:
     def working_dir(self):
         """Lazy initialization of the working directory."""
         if self._working_dir is None:
-            temp_dir = tempfile.TemporaryDirectory(prefix="Terminal-")
-            atexit.register(temp_dir.cleanup)
-            self._working_dir = temp_dir.name
+            _tempdir = tempfile.TemporaryDirectory(prefix="Terminal-")
+            atexit.register(_tempdir.cleanup)
+            self._working_dir = str(Path(_tempdir.name).resolve())
             self.logger.debug(f"Using temporary working directory: {self._working_dir}")
         return self._working_dir
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 norecursedirs = data/*
 asyncio_default_fixture_loop_scope = function
+env =
+    BASH_SILENCE_DEPRECATION_WARNING=1  # Suppress deprecation warnings in MacOS (zsh default)

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -541,11 +541,11 @@ def test_queue_and_process_events():
 def test_resolve_path(tmp_path, debugignore):
     (tmp_path / ".debugignore").write_text(debugignore)
     env = RepoEnv(path=tmp_path)
-    abs_path = (env.working_dir / "file.txt").resolve()
+    abs_path = (env.working_dir / "file.txt").absolute()
     (abs_path).touch()
     # env.working_dir itself
     path_from_env = env.resolve_path(str(env.working_dir), raises=True)
-    assert path_from_env == env.working_dir.resolve()
+    assert path_from_env == env.working_dir.absolute()
     # relative path
     path_from_env = env.resolve_path("file.txt")
     assert path_from_env == abs_path
@@ -563,10 +563,10 @@ def test_resolve_path(tmp_path, debugignore):
     assert path_from_env == abs_path
     # return an absolute path regardless of existence
     non_existent_path = env.resolve_path("non_existent_file.txt")
-    assert non_existent_path == (env.working_dir / "non_existent_file.txt").resolve()
+    assert non_existent_path == (env.working_dir / "non_existent_file.txt").absolute()
     # non-existent absolute path
     non_existent_path = env.resolve_path("/tmp/non_existent_file.txt")
-    assert non_existent_path == Path("/tmp/non_existent_file.txt").resolve()
+    assert non_existent_path == Path("/tmp/non_existent_file.txt").absolute()
 
 
 def test_resolve_path_raises(tmp_path):

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -130,10 +130,10 @@ def test_setup_workspace(mock_atexit_register, mock_tempdir, tmp_path):
 
     assert repo_env.path == path_dir
     assert repo_env.working_dir == working_dir
-    assert repo_env.tempdir.startswith("RepoEnv-")
+    assert repo_env._tempdir.startswith("RepoEnv-")
     with open(working_dir / "file.py", "r") as f:
         assert f.read() == file_content
-    mock_atexit_register.assert_called_once_with(repo_env.tempdir.cleanup)
+    mock_atexit_register.assert_called_once_with(repo_env._tempdir.cleanup)
 
 
 @patch("tempfile.TemporaryDirectory")
@@ -156,7 +156,7 @@ def test_cleanup_workspace(mock_tempdir):
     mock_tempdir_instance = MagicMock()
     mock_tempdir.return_value = mock_tempdir_instance
     env = RepoEnv()
-    env.tempdir = mock_tempdir_instance
+    env._tempdir = mock_tempdir_instance
     env.cleanup_workspace()
 
     mock_tempdir_instance.cleanup.assert_called_once()
@@ -324,7 +324,7 @@ def test_reset(
         all_observations=[Observation(source="env", observation="1 failed, 0 passed")],
         eval_observation=Observation(source="env", observation="1 failed, 0 passed"),
         dir_tree=f"""Listing files in the current working directory. (read-only) indicates read-only files. Max depth: 2.
-{env.tempdir.name}/
+{env.working_dir}/
 |-- file1.txt
 |-- file2.txt
 |-- subdir/

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -541,11 +541,11 @@ def test_queue_and_process_events():
 def test_resolve_path(tmp_path, debugignore):
     (tmp_path / ".debugignore").write_text(debugignore)
     env = RepoEnv(path=tmp_path)
-    abs_path = (env.working_dir / "file.txt").absolute()
+    abs_path = (env.working_dir / "file.txt").resolve()
     (abs_path).touch()
     # env.working_dir itself
     path_from_env = env.resolve_path(str(env.working_dir), raises=True)
-    assert path_from_env == env.working_dir.absolute()
+    assert path_from_env == env.working_dir.resolve()
     # relative path
     path_from_env = env.resolve_path("file.txt")
     assert path_from_env == abs_path
@@ -563,10 +563,10 @@ def test_resolve_path(tmp_path, debugignore):
     assert path_from_env == abs_path
     # return an absolute path regardless of existence
     non_existent_path = env.resolve_path("non_existent_file.txt")
-    assert non_existent_path == (env.working_dir / "non_existent_file.txt").absolute()
+    assert non_existent_path == (env.working_dir / "non_existent_file.txt").resolve()
     # non-existent absolute path
     non_existent_path = env.resolve_path("/tmp/non_existent_file.txt")
-    assert non_existent_path == Path("/tmp/non_existent_file.txt").absolute()
+    assert non_existent_path == Path("/tmp/non_existent_file.txt").resolve()
 
 
 def test_resolve_path_raises(tmp_path):

--- a/tests/gym/envs/test_env.py
+++ b/tests/gym/envs/test_env.py
@@ -565,7 +565,7 @@ def test_resolve_path(tmp_path, debugignore):
     non_existent_path = env.resolve_path("non_existent_file.txt")
     assert non_existent_path == (env.working_dir / "non_existent_file.txt").resolve()
     # non-existent absolute path
-    non_existent_path = env.resolve_path("/tmp/non_existent_file.txt")
+    non_existent_path = env.resolve_path("/tmp/non_existent_file.txt").resolve()
     assert non_existent_path == Path("/tmp/non_existent_file.txt").resolve()
 
 

--- a/tests/gym/envs/test_swe_bench.py
+++ b/tests/gym/envs/test_swe_bench.py
@@ -10,8 +10,17 @@ from debug_gym.gym.terminal import DockerTerminal
 from debug_gym.gym.tools.tool import ToolCall
 from debug_gym.gym.tools.toolbox import Toolbox
 
+
+def is_docker_running():
+    try:
+        subprocess.check_output(["docker", "ps"])
+        return True
+    except Exception:
+        return False
+
+
 if_docker_running = pytest.mark.skipif(
-    not subprocess.check_output(["docker", "ps"]),
+    not is_docker_running(),
     reason="Docker not running",
 )
 

--- a/tests/gym/envs/test_swe_smith.py
+++ b/tests/gym/envs/test_swe_smith.py
@@ -10,8 +10,17 @@ from debug_gym.gym.terminal import DockerTerminal
 from debug_gym.gym.tools.tool import ToolCall
 from debug_gym.gym.tools.toolbox import Toolbox
 
+
+def is_docker_running():
+    try:
+        subprocess.check_output(["docker", "ps"])
+        return True
+    except Exception:
+        return False
+
+
 if_docker_running = pytest.mark.skipif(
-    not subprocess.check_output(["docker", "ps"]),
+    not is_docker_running(),
     reason="Docker not running",
 )
 

--- a/tests/gym/tools/test_pdb.py
+++ b/tests/gym/tools/test_pdb.py
@@ -1,4 +1,5 @@
 import copy
+import platform
 import re
 import subprocess
 from unittest.mock import MagicMock
@@ -10,9 +11,24 @@ from debug_gym.gym.envs.env import RepoEnv
 from debug_gym.gym.terminal import DockerTerminal, Terminal
 from debug_gym.gym.tools.pdb import PDBTool
 
+
+def is_docker_running():
+    try:
+        subprocess.check_output(["docker", "ps"])
+        return True
+    except Exception:
+        return False
+
+
 if_docker_running = pytest.mark.skipif(
-    not subprocess.check_output(["docker", "ps"]),
+    not is_docker_running(),
     reason="Docker not running",
+)
+
+
+if_is_linux = pytest.mark.skipif(
+    platform.system() != "Linux",
+    reason="Interactive ShellSession (pty) requires Linux.",
 )
 
 
@@ -165,6 +181,7 @@ def test_pdb_use_default_environment_entrypoint(tmp_path, setup_test_repo):
     assert "(Pdb)" not in output
 
 
+@if_is_linux
 @if_docker_running
 def test_pdb_use_docker_terminal(tmp_path, setup_test_repo):
     """Test PDBTool similar to test_pdb_use but using DockerTerminal"""


### PR DESCRIPTION
On macOS, all copied files under `/var` are actually symlinked to `/private/var`.
Currently, `resolve_path()` calls `.resolve()`, and that being the case, a tool-supplied relative filepath (e.g., `test.py`) is converted & expanded to `/private/var/folders/.../RepoEnv-XXXX/test.py`, while the working directory of the corresponding `RepoEnv` instance remains `/var/folders/.../RepoEnv-XXXX`. 
As expected, a consequent `FileNotFoundError` is raised, even though the file is present.

<img width="1400" alt="path-mismatch" src="https://github.com/user-attachments/assets/80378ae3-b8cc-4d9e-8641-7c3606953a11" />



By letting the working_dir to directly use `.resolve()`, we ensure that it is fully resolved to its canonical path, avoiding symlink-related mismatches.