### PR TITLE
Fix init obs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ vscode/out
 vscode/node_modules
 vscode/package-lock.json
 .vscode
+debug_gym/llms/claude.py

--- a/debug_gym/agents/base_agent.py
+++ b/debug_gym/agents/base_agent.py
@@ -58,7 +58,7 @@ class BaseAgent:
 
     def build_history_prompt(self):
         messages = build_history_prompt(
-            self.history.filter_out(actions=[None]),
+            self.history,
             self.llm,
             self.config["reset_prompt_history_after_rewrite"],
         )

--- a/debug_gym/agents/history_tracker.py
+++ b/debug_gym/agents/history_tracker.py
@@ -83,13 +83,6 @@ class HistoryTracker:
     def clone(self):
         return copy.deepcopy(self)
 
-    def filter_out(self, actions: list[str]):
-        history = HistoryTracker(self.history_steps)
-        for info, llm_response in zip(self.memory, self.prompt_response_pairs):
-            if getattr(info.action, "name", None) not in actions:
-                history.step(info, llm_response)
-        return history
-
 
 def build_history_prompt(
     history: HistoryTracker, llm: LLM, reset_prompt_history_after_rewrite: bool = False

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -111,35 +111,54 @@ class AnthropicLLM(LLM):
         )
 
     def format_tool_call_history(
-        self, history_info: EnvInfo, response: LLMResponse
+        self, history_info: EnvInfo, response: list[LLMResponse | None]
     ) -> list[dict]:
-        _messages = [
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "type": "tool_use",
-                        "id": response[0].tool.id,  # 'toolu_01SdR84CsnTKRpdH4zwFjvGj'
-                        "name": response[0].tool.name,  # 'view'
-                        "input": response[
-                            0
-                        ].tool.arguments,  # {'path': 'hangman_test.py'}
-                    }
-                ],
-            },
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": history_info.action.id,  # 'toolu_01SdR84CsnTKRpdH4zwFjvGj'
-                        "content": filter_non_utf8(
-                            f"{history_info.step_observation.observation}"
-                        ),  # 'Viewing `hangman_test.py`. The file is read-only, it is not editable.'
-                    }
-                ],
-            },
-        ]
+        _messages = []
+        if isinstance(response, list) and len(response) > 0:
+            _messages.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": response[
+                                0
+                            ].tool.id,  # 'toolu_01SdR84CsnTKRpdH4zwFjvGj'
+                            "name": response[0].tool.name,  # 'view'
+                            "input": response[
+                                0
+                            ].tool.arguments,  # {'path': 'hangman_test.py'}
+                        }
+                    ],
+                }
+            )
+        if history_info.action is None:
+            # This is the initial state, no action taken yet
+            _messages.append(
+                {
+                    "role": "user",
+                    "content": filter_non_utf8(
+                        "{history_info.step_observation.observation}"
+                    ),
+                }
+            )
+        else:
+            # This is a step with an action taken
+            _messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": history_info.action.id,  # 'toolu_01SdR84CsnTKRpdH4zwFjvGj'
+                            "content": filter_non_utf8(
+                                f"{history_info.step_observation.observation}"
+                            ),  # 'Viewing `hangman_test.py`. The file is read-only, it is not editable.'
+                        }
+                    ],
+                }
+            )
+
         return _messages
 
     def generate(self, messages, tools, **kwargs) -> LLMResponse:

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -138,7 +138,7 @@ class AnthropicLLM(LLM):
                 {
                     "role": "user",
                     "content": filter_non_utf8(
-                        "{history_info.step_observation.observation}"
+                        f"{history_info.step_observation.observation}"
                     ),
                 }
             )

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -111,7 +111,7 @@ class AnthropicLLM(LLM):
         )
 
     def format_tool_call_history(
-        self, history_info: EnvInfo, response: list[LLMResponse | None]
+        self, history_info: EnvInfo, response: list[LLMResponse]
     ) -> list[dict]:
         _messages = []
         if isinstance(response, list) and len(response) > 0:

--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -155,7 +155,7 @@ class OpenAILLM(LLM):
         )
 
     def format_tool_call_history(
-        self, history_info: EnvInfo, response: list[LLMResponse | None]
+        self, history_info: EnvInfo, response: list[LLMResponse]
     ) -> list[dict]:
         _messages = []
         if isinstance(response, list) and len(response) > 0:

--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -155,31 +155,48 @@ class OpenAILLM(LLM):
         )
 
     def format_tool_call_history(
-        self, history_info: EnvInfo, response: LLMResponse
+        self, history_info: EnvInfo, response: list[LLMResponse | None]
     ) -> list[dict]:
-        _messages = [
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "type": "function",
-                        "id": response[0].tool.id,
-                        "function": {
-                            "name": response[0].tool.name,
-                            "arguments": json.dumps(response[0].tool.arguments),
+        _messages = []
+        if isinstance(response, list) and len(response) > 0:
+            _messages.append(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "id": response[0].tool.id,
+                            "function": {
+                                "name": response[0].tool.name,
+                                "arguments": json.dumps(response[0].tool.arguments),
+                            },
                         },
-                    },
-                ],
-            },
-            {
-                "role": "tool",
-                "tool_call_id": history_info.action.id,
-                "name": history_info.action.name,
-                "content": filter_non_utf8(
-                    f"{history_info.step_observation.observation}"
-                ),
-            },
-        ]
+                    ],
+                }
+            )
+        if history_info.action is None:
+            # This is the initial state, no action taken yet
+            _messages.append(
+                {
+                    "role": "user",
+                    "content": filter_non_utf8(
+                        f"{history_info.step_observation.observation}"
+                    ),
+                }
+            )
+        else:
+            # This is a step with an action taken
+            _messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": history_info.action.id,
+                    "name": history_info.action.name,
+                    "content": filter_non_utf8(
+                        f"{history_info.step_observation.observation}"
+                    ),
+                }
+            )
+
         return _messages
 
     def generate(self, messages, tools, **kwargs) -> LLMResponse:

--- a/tests/agents/test_history_tracker.py
+++ b/tests/agents/test_history_tracker.py
@@ -153,12 +153,6 @@ def test_history_tracker(build_env_info):
     assert ht_clone.history_steps == ht.history_steps
     assert ht_clone is not ht
 
-    # test filtering out
-    ht_filtered = ht.filter_out(actions=["action2", "action4"])
-    for step in ht_filtered.get_all():
-        assert step.action not in [tool_2, tool_4]
-        assert step.action in [None, tool_3, tool_5]
-
     # should reset properly
     ht.reset()
     assert len(ht) == 0


### PR DESCRIPTION
In previous versions of the code, the `build_history_prompt` method was filtering out actions with a `None` value. This will cause the agent to miss the initial observation. 