### PR TITLE
Add get_problem_ids (formerly get_dataset_split) to all benchmark env

### DIFF
--- a/debug_gym/gym/envs/aider.py
+++ b/debug_gym/gym/envs/aider.py
@@ -81,3 +81,13 @@ class AiderBenchmarkEnv(RepoEnv):
                 "instructions": instructions,
                 "filename": task_name + ".py",
             }
+
+    def get_problem_ids(self, split_or_problem_id):
+        if split_or_problem_id == "all":
+            return sorted(self.dataset.keys())  # all tasks
+        elif split_or_problem_id in self.dataset:
+            return [split_or_problem_id]  # Single task
+        else:
+            raise ValueError(
+                f"Invalid split or problem id: '{split_or_problem_id}'.\nChoose from: {['all'] + sorted(self.dataset.keys())}"
+            )

--- a/debug_gym/gym/envs/swe_bench.py
+++ b/debug_gym/gym/envs/swe_bench.py
@@ -80,6 +80,16 @@ class SWEBenchEnv(RepoEnv):
                 max_workers=24,
             )
 
+    def get_problem_ids(self, split_or_problem_id):
+        if split_or_problem_id == "all":
+            return sorted(self.dataset.keys())  # all tasks
+        elif split_or_problem_id in self.dataset:
+            return [split_or_problem_id]  # Single task
+        else:
+            raise ValueError(
+                f"Invalid split or problem id: '{split_or_problem_id}'.\nChoose from: {['all'] + sorted(self.dataset.keys())}"
+            )
+
     def setup_task(self, task_name):
         if self.instance_ids:
             if task_name not in self.instance_ids:

--- a/debug_gym/gym/envs/swe_smith.py
+++ b/debug_gym/gym/envs/swe_smith.py
@@ -95,18 +95,18 @@ class SWESmithEnv(SWEBenchEnv):
             self.dataset_splits = yaml.safe_load(f)
             self.excluded_ids = self.dataset_splits.get("excluded", [])
 
-    def get_dataset_split(self, split):
-        if split == "all":
+    def get_problem_ids(self, split_or_problem_id):
+        if split_or_problem_id == "all":
             return sorted(
                 k for k in self.dataset.keys() if k not in self.excluded_ids
             )  # all tasks
-        elif split in self.dataset:
-            return [split]  # Single task
-        elif split in self.dataset_splits:
-            return self.dataset_splits[split]
+        elif split_or_problem_id in self.dataset:
+            return [split_or_problem_id]  # Single task
+        elif split_or_problem_id in self.dataset_splits:
+            return self.dataset_splits[split_or_problem_id]
         else:
             raise ValueError(
-                f"Invalid split '{split}'. Available splits are: {['all'] + sorted(self.dataset_splits.keys())}"
+                f"Invalid split or problem id: '{split_or_problem_id}'. Available splits are: {['all'] + sorted(self.dataset_splits.keys())}"
             )
 
     def setup_task(self, task_name):

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -103,10 +103,7 @@ def main():
     problems = config.get("problems", ["custom"])
     if isinstance(problems, str) and "benchmark" in config:
         env = create_env(config, logger=logger)
-        if problems == "all":
-            problems = sorted(env.dataset.keys())  # all tasks
-        else:
-            problems = env.get_dataset_split(problems)
+        problems = env.get_problem_ids(split_or_problem_id=problems)
 
     if args.list:
         print(f"\n# Available problems in {config.get('benchmark', 'config')}:")

--- a/tests/gym/envs/test_aider.py
+++ b/tests/gym/envs/test_aider.py
@@ -101,3 +101,22 @@ def test_steps(env):
 
 def test_instructions(env):
     assert env.instructions == "What time is it?"
+
+
+def test_get_problem_ids(env):
+    # Test retrieving all problem IDs
+    all_problem_ids = env.get_problem_ids("all")
+    assert isinstance(all_problem_ids, list)
+    assert len(all_problem_ids) > 0
+    assert all(isinstance(problem_id, str) for problem_id in all_problem_ids)
+
+    # Test retrieving a single valid problem ID
+    valid_problem_id = all_problem_ids[0]
+    single_problem_id = env.get_problem_ids(valid_problem_id)
+    assert isinstance(single_problem_id, list)
+    assert len(single_problem_id) == 1
+    assert single_problem_id[0] == valid_problem_id
+
+    # Test retrieving an invalid problem ID
+    with pytest.raises(ValueError, match="Invalid split or problem id: 'invalid_id'"):
+        env.get_problem_ids("invalid_id")

--- a/tests/gym/envs/test_swe_bench.py
+++ b/tests/gym/envs/test_swe_bench.py
@@ -322,3 +322,30 @@ def test_apply_gold_patch(tmp_path, get_swe_env):
     score = swe_env.calculate_score(eval_output)
 
     assert score == swe_env.max_score
+
+
+def test_get_problem_ids(get_swe_env):
+    swe_env = get_swe_env()
+
+    # Test retrieving all problem IDs
+    problem_ids = swe_env.get_problem_ids("all")
+    assert isinstance(problem_ids, list), "Expected a list of problem IDs"
+    assert len(problem_ids) > 0, "Expected at least one problem ID"
+    assert all(
+        isinstance(pid, str) for pid in problem_ids
+    ), "All problem IDs should be strings"
+    assert sorted(problem_ids) == problem_ids, "Problem IDs should be sorted"
+
+    # Test retrieving a single valid problem ID
+    task_name = "astropy__astropy-14096"
+    problem_ids = swe_env.get_problem_ids(task_name)
+    assert isinstance(problem_ids, list), "Expected a list of problem IDs"
+    assert len(problem_ids) == 1, "Expected exactly one problem ID"
+    assert problem_ids[0] == task_name, f"Expected problem ID to be {task_name}"
+
+    # Test retrieving an invalid problem ID
+    invalid_task_name = "non_existent_task"
+    with pytest.raises(
+        ValueError, match=f"Invalid split or problem id: '{invalid_task_name}'"
+    ):
+        swe_env.get_problem_ids(invalid_task_name)

--- a/tests/gym/envs/test_swe_smith.py
+++ b/tests/gym/envs/test_swe_smith.py
@@ -227,3 +227,34 @@ def test_calculate_score_with_pytest_error(get_swe_env):
 
     score = swe_env.calculate_score(eval_output)
     assert score == 0
+
+
+def test_get_problem_ids_all(get_swe_env):
+    swe_env = get_swe_env()
+    swe_env.excluded_ids = ["excluded_task_1", "excluded_task_2"]
+    swe_env.dataset = {
+        "task_1": 0,
+        "task_2": 1,
+        "excluded_task_1": 2,
+        "excluded_task_2": 3,
+    }
+
+    # Test retrieving all problem IDs
+    problem_ids = swe_env.get_problem_ids("all")
+    assert problem_ids == ["task_1", "task_2"]
+
+    # Test retrieving a single valid problem ID
+    swe_env.dataset = {"task_1": 0, "task_2": 1}
+    problem_ids = swe_env.get_problem_ids("task_1")
+    assert problem_ids == ["task_1"]
+
+    # Test retrieving a valid split.
+    swe_env.dataset_splits = {"split_1": ["task_1", "task_2"]}
+    problem_ids = swe_env.get_problem_ids("split_1")
+    assert problem_ids == ["task_1", "task_2"]
+
+    # Test retrieving an invalid problem ID
+    swe_env.dataset = {"task_1": 0}
+    swe_env.dataset_splits = {"split_1": ["task_1"]}
+    with pytest.raises(ValueError, match="Invalid split or problem id: 'invalid_id'"):
+        swe_env.get_problem_ids("invalid_id")


### PR DESCRIPTION
This pull request introduces a new `get_problem_ids` method across multiple environments to unify the way problem IDs are retrieved and validated. It also updates the relevant code and adds comprehensive tests to ensure the method's correctness and robustness.

### New method implementation:

* Added `get_problem_ids` method to the following files to standardize problem ID retrieval:
  - `debug_gym/gym/envs/aider.py`
  - `debug_gym/gym/envs/swe_bench.py`
  - `debug_gym/gym/envs/swe_smith.py`, replacing the previous `get_dataset_split` method

### Code updates for integration:

* Updated `scripts/run.py` to use the new `get_problem_ids` method instead of `get_dataset_split`. This ensures consistency across environments.

### Test coverage improvements:

* Added unit tests for `get_problem_ids` in the following test files:
  - `tests/gym/envs/test_aider.py`
  - `tests/gym/envs/test_swe_bench.py`
  - `tests/gym/envs/test_swe_smith.py`
