### PR TITLE
Pin swe-smith version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ transformers
 tiktoken
 docker
 swebench==4.0.3
-swesmith
+swesmith==0.0.4
 prompt_toolkit
 anthropic>=0.49.0
 jinja2


### PR DESCRIPTION
Pin swe-smith version to avoid `ImportError: cannot import name 'MAP_REPO_TO_SPECS' from 'swesmith.constants'`