### PR TITLE
Change to when tool call is on auto parsing 

### DIFF
--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -219,7 +219,7 @@ class OpenAILLM(LLM):
             raise
 
         # LLM may select multiple tool calls, we only care about the first action
-        if response.choices[0].message.tool_calls is None:
+        if not response.choices[0].message.tool_calls:
             # LLM failed to call a tool
             tool_call = None
         else:


### PR DESCRIPTION
Change in debug_gym/llms/openai.py for when a tool call could be an empty list as well as None. This prevents this error: 

```
       │ /home/t-iwhite/debug-gym/debug_gym/llms/base.py:351 in generate_with_drop_message_and_retry                                 │          
         │                                                                                                                             │          
         │   348 │   │   │   if not messages:                                                                                          │          
         │   349 │   │   │   │   raise ValueError("No messages provided for generation.")                                              │          
         │   350 │   │   │   try:                                                                                                      │          
         │ ❱ 351 │   │   │   │   llm_response = self.generate(messages, tools, **kwargs)                                               │          
         │   352 │   │   │   except ContextLengthExceededError:                                                                        │          
         │   353 │   │   │   │   self.logger.info(                                                                                     │          
         │   354 │   │   │   │   │   f"Prompt is too long. {self.model_name} only allows for                                           │          
         │       {self.context_length:,} tokens."                                                                                      │          
         │                                                                                                                             │          
         │ /home/t-iwhite/debug-gym/debug_gym/llms/openai.py:226 in generate                                                           │          
         │                                                                                                                             │          
         │   223 │   │   │   # LLM failed to call a tool                                                                               │          
         │   224 │   │   │   tool_call = None                                                                                          │          
         │   225 │   │   else:                                                                                                         │          
         │ ❱ 226 │   │   │   tool_call = response.choices[0].message.tool_calls[0]                                                     │          
         │   227 │   │   │   assert tool_call.type == "function"  
```