### PR TITLE
Deal with new SWE-Smith dataset on Huggingface

### DIFF
--- a/debug_gym/gym/envs/swe_smith.py
+++ b/debug_gym/gym/envs/swe_smith.py
@@ -73,7 +73,7 @@ class SWESmithEnv(SWEBenchEnv):
 
         # Download all images needed for SWE-Smith.
         client = docker.from_env()
-        tagged_image_names = set(f"{DOCKER_ORG}/{name}:{TAG}" for name in image_names)
+        tagged_image_names = set(f"{name}:{TAG}" for name in image_names)
 
         existing_images = set(
             tag for image in client.images.list() for tag in image.tags
@@ -82,13 +82,8 @@ class SWESmithEnv(SWEBenchEnv):
         if missing_images:
             self.logger.info(f"Found {len(missing_images)} missing Docker images.")
             for image_name in missing_images:
-                docker_hub_image = image_name.replace("__", "_1776_")
-                self.logger.info(
-                    f"Pulling Docker image `{docker_hub_image}` to `{image_name}`."
-                )
-                client.images.pull(docker_hub_image)
-                # Rename images via tagging
-                client.images.get(docker_hub_image).tag(image_name)
+                self.logger.info(f"Pulling Docker image `{image_name}`.")
+                client.images.pull(image_name)
 
         # Load dataset splits.
         with open(SWESmithEnv.CONFIG) as f:


### PR DESCRIPTION
This pull request simplifies the process of handling Docker images in the `load_dataset` method of the `debug_gym/gym/envs/swe_smith.py` file. The changes remove unnecessary renaming of Docker images and streamline the logic for pulling images.

### Simplification of Docker image handling:

* Removed the prefix `DOCKER_ORG/` from tagged image names, simplifying the format to just `name:TAG`. (`[debug_gym/gym/envs/swe_smith.pyL76-R76](diffhunk://#diff-dc23c08d05edaeab65b40bf7c47817882fcf7469572cb67b26973049578cda7dL76-R76)`)
* Eliminated the logic for renaming Docker images (e.g., replacing `__` with `_1776_`) and tagging them after pulling. Docker images are now pulled directly using their original names. (`[debug_gym/gym/envs/swe_smith.pyL85-R86](diffhunk://#diff-dc23c08d05edaeab65b40bf7c47817882fcf7469572cb67b26973049578cda7dL85-R86)`)