### PR TITLE
Dump experiment info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
+          pip install build
           pip install -e '.[dev]'
 
       - name: Save version and commit hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all tags
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,9 @@
 name: PyPI Release
 
-# on:
-#   push:
-#     tags:
-#       - 'v*'  # Only publish on version tags
 on:
-  pull_request:
-    branches: [ "main" ]
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-and-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: PyPI Release
+
+# on:
+#   push:
+#     tags:
+#       - 'v*'  # Only publish on version tags
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Save version and commit hash
+        # Equivalent to `VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')"`
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          echo "__version__ = \"${VERSION}\"" > debug_gym/version.py
+          echo "__commit__ = \"${COMMIT}\"" >> debug_gym/version.py
+          echo "__version__ = \"${VERSION}\""
+          echo "__commit__ = \"${COMMIT}\""
+
+      - name: Build package
+        run: python -m build
+
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all tags
+          fetch-tags: true  # Fetch all tags so we can get the latest version
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true  # Fetch all tags so we can get the latest version
+          fetch-depth: 0  # Fetch all tags so we can get the latest version
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Build package
         run: python -m build
 
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all tags so we can get the latest version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -24,15 +22,6 @@ jobs:
           pip install --upgrade pip
           pip install build
           pip install -e '.[dev]'
-
-      - name: Save version and commit hash
-        run: |
-          VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')"
-          COMMIT="$(git rev-parse --short HEAD)"
-          echo "__version__ = \"${VERSION}\"" > debug_gym/version.py
-          echo "__commit__ = \"${COMMIT}\"" >> debug_gym/version.py
-          echo "__version__ = \"${VERSION}\""
-          echo "__commit__ = \"${COMMIT}\""
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,8 @@ jobs:
           pip install -e '.[dev]'
 
       - name: Save version and commit hash
-        # Equivalent to `VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')"`
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')"
           COMMIT="$(git rev-parse --short HEAD)"
           echo "__version__ = \"${VERSION}\"" > debug_gym/version.py
           echo "__commit__ = \"${COMMIT}\"" >> debug_gym/version.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/debug_gym/version.py
+++ b/debug_gym/version.py
@@ -1,2 +1,1 @@
 __version__ = "1.0.0"
-__commit__ = "f328f9e9bcbb7b4610592fa1c27d155049f086f7"

--- a/debug_gym/version.py
+++ b/debug_gym/version.py
@@ -1,1 +1,2 @@
 __version__ = "1.0.0"
+__commit__ = "f328f9e9bcbb7b4610592fa1c27d155049f086f7"

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,10 +1,13 @@
+import datetime
 import json
 import os
 import signal
+import subprocess
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
+from debug_gym import version as dg_version
 from debug_gym.agents.base_agent import AGENT_REGISTRY, create_agent
 from debug_gym.agents.utils import load_config
 from debug_gym.gym.envs import select_env
@@ -185,12 +188,60 @@ def add_tools(env, config: dict, logger: DebugGymLogger):
         logger.debug(f"Adding tool to toolbox: {tool_instantiated.__class__.__name__}")
 
 
+def dump_experiment_info(config: dict, args: dict):
+    """Dump experiment information to a JSONL file.
+    Each line is one experiment run with its metadata."""
+
+    try:  # Get debug-gym version
+        debug_gym_version = dg_version.__version__
+    except Exception:
+        debug_gym_version = ""
+
+    try:  # Get git commit hash
+        git_hash = (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=os.path.dirname(__file__)
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        git_hash = ""
+
+    try:  # Get git diff
+        git_diff = subprocess.check_output(
+            ["git", "diff"], cwd=os.path.dirname(__file__)
+        ).decode()
+    except Exception:
+        git_diff = ""
+
+    version_info = {
+        "debug_gym_version": debug_gym_version,
+        "datetime": datetime.datetime.now().isoformat(),
+        "git_hash": git_hash,
+        "git_diff": git_diff,
+        "config": config,
+        "args": vars(args),
+        "python_version": os.sys.version,
+    }
+
+    file = Path(config["output_path"]) / config["uuid"] / "experiment_info.jsonl"
+    with open(file, "a") as f:
+        f.write(f"{json.dumps(version_info)}\n")
+
+
 def main():
     config, args = load_config()
     logger = DebugGymLogger("debug-gym", level=args.logging_level)
 
     config["uuid"] = config.get("uuid", str(uuid.uuid4()))
-    logger.info(f"Experiment log path: {config['output_path']}/{config['uuid']}")
+
+    exp_output_path = Path(config["output_path"]) / config["uuid"]
+    exp_output_path.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"Experiment log path: {exp_output_path}")
+
+    dump_experiment_info(config, args)
 
     # Figure out which problems to solve.
     problems = config.get("problems", ["custom"])


### PR DESCRIPTION
Log detailed experiment metadata, including versioning and configuration details, in the `scripts/run.py` file. The changes include adding a new utility function, `dump_experiment_info`, and updating the main script to ensure experiment metadata is saved in a structured format.

**New `dump_experiment_info` function**: Added a utility function to log experiment metadata, including the `debug-gym` version, current datetime, Git commit hash, Git diff, Python version, and experiment configuration. The metadata is saved in a JSONL file within the experiment's output directory. (`[scripts/run.pyR191-R244](diffhunk://#diff-31f00059cd1ed0d328e70d7f85c8c908e9252130223c372c3e24397c3ebe06a0R191-R244)`)