### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 jobs:
-  build-and-publish:
+  build-package:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -26,5 +26,27 @@ jobs:
       - name: Build package
         run: python -m build
 
+      - name: Upload distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-release
+      url: https://pypi.org/p/debug-gym
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist


### PR DESCRIPTION
* Add environment and id-token permission.
* Split build and publish in two steps following their pro tip:
> Pro tip: only set the id-token: write permission in the job that does publishing, not globally. Also, try to separate building from publishing — this makes sure that any scripts maliciously injected into the build or test environment won't be able to elevate privileges while flying under the radar.