### PR TITLE
Avoid copying __pycache__ in the temp workding dir.

### DIFF
--- a/debug_gym/gym/envs/env.py
+++ b/debug_gym/gym/envs/env.py
@@ -228,7 +228,13 @@ class RepoEnv(TooledEnv):
         atexit.register(self._tempdir.cleanup)
 
         self.logger.debug(f"Working directory: {self.working_dir}")
-        shutil.copytree(self.path, self.working_dir, dirs_exist_ok=True, symlinks=True)
+        shutil.copytree(
+            self.path,
+            self.working_dir,
+            dirs_exist_ok=True,
+            symlinks=True,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
 
         self.setup_file_filters(readonly_patterns, ignore_patterns)
 

--- a/debug_gym/gym/tools/pdb.py
+++ b/debug_gym/gym/tools/pdb.py
@@ -156,7 +156,6 @@ class PDBTool(EnvironmentTool):
         else:  # other pdb commands, send directly
             try:
                 pdb_out = self.interact_with_pdb(command, environment.run_timeout)
-                # remove the working dir from the output
                 if pdb_out in (
                     "End of file",
                     "Blank or comment",

--- a/debug_gym/gym/tools/pdb.py
+++ b/debug_gym/gym/tools/pdb.py
@@ -157,7 +157,6 @@ class PDBTool(EnvironmentTool):
             try:
                 pdb_out = self.interact_with_pdb(command, environment.run_timeout)
                 # remove the working dir from the output
-                pdb_out = pdb_out.replace(f"{environment.working_dir}/", "")
                 if pdb_out in (
                     "End of file",
                     "Blank or comment",

--- a/scripts/config_mini_nightmare.yaml
+++ b/scripts/config_mini_nightmare.yaml
@@ -4,7 +4,7 @@ base:
     benchmark: "mini_nightmare"
     problems: "all"  # list of problems, e.g., ["config"], or "all"
     env_kwargs: {
-        "entrypoint": "python -m pytest -s test.py",
+        "entrypoint": "python -m pytest --tb=no -s test.py",
         "dir_tree_depth": 1,
         "run_timeout": 30,
         # shortcut features


### PR DESCRIPTION
This pull request includes changes to improve workspace setup, streamline output handling, and enhance configuration for testing. The most important updates include adding file filters during workspace copying, modifying the way working directory paths are handled in output, and updating the test entry point for cleaner traceback output.

### Workspace setup improvements:
* [`debug_gym/gym/envs/env.py`](diffhunk://#diff-dd500acaa499f131456c6cd77f9310117f349f19f869fc0fcb4279f71025f108L231-R237): Enhanced the `setup_workspace` method by adding file filters to ignore `__pycache__` and `.pyc` files during directory copying.

### Output handling improvements:
* [`debug_gym/gym/tools/pdb.py`](diffhunk://#diff-76652796cb2c3b55f1ed3b66896c9e0e6cfcfa3ff8e54e8dd7e7b65dabc8f100L160): Simplified the handling of output paths by removing the replacement of the working directory prefix with an empty string.

### Testing configuration enhancements:
* [`scripts/config_mini_nightmare.yaml`](diffhunk://#diff-8b1170dceb4870f28ae9f00425abdbd14207448da847fcfdc58087e399ff5cceL7-R7): Updated the `entrypoint` command to suppress traceback details (`--tb=no`) for cleaner test output.