### PR TITLE
Make DebugGymLogger a singleton

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -259,7 +259,6 @@ def main():
     llm = LLM.instantiate(
         llm_name=config["llm_name"],
         llm_config_file_path=config.get("llm_config_file_path"),
-        logger=None,
     )
 
     # Stop live progress display if --no-live-display is set


### PR DESCRIPTION
This pull request introduces a singleton pattern to the `DebugGymLogger` class, ensuring only one instance of the logger is created, and removes an unused `logger` parameter from the instantiation of the `LLM` class in the `scripts/run.py` file.

### Changes to `DebugGymLogger`:

* Added a singleton pattern to the `DebugGymLogger` class by implementing the `__new__` method and introducing an `_instance` class attribute. This ensures that only one instance of the logger is created. (`debug_gym/logger.py`, [debug_gym/logger.pyR416-R424](diffhunk://#diff-8b9d7e41d6e0e64e597907fef79c888758736af50ab82935e5cda12ff50d66cdR416-R424))
* Updated the `__init__` method to check if the logger instance is already initialized and to skip reinitialization if `_initialized` is `True`. (`debug_gym/logger.py`, [debug_gym/logger.pyR433-R435](diffhunk://#diff-8b9d7e41d6e0e64e597907fef79c888758736af50ab82935e5cda12ff50d66cdR433-R435))
* Marked the logger instance as initialized by setting `_initialized` to `True` after completing the initialization process. (`debug_gym/logger.py`, [debug_gym/logger.pyR458-R459](diffhunk://#diff-8b9d7e41d6e0e64e597907fef79c888758736af50ab82935e5cda12ff50d66cdR458-R459))

### Changes to `scripts/run.py`:

* Removed the unused `logger` parameter from the `LLM.instantiate` call in the `main` function, simplifying the code. (`scripts/run.py`, [scripts/run.pyL262](diffhunk://#diff-31f00059cd1ed0d328e70d7f85c8c908e9252130223c372c3e24397c3ebe06a0L262))