### PR TITLE
Fix log none plus tool call

### DIFF
--- a/debug_gym/gym/utils.py
+++ b/debug_gym/gym/utils.py
@@ -15,6 +15,8 @@ def clean_code(code):
 
 def filter_non_utf8(text):
     """Filter out non-UTF-8 characters from text."""
+    if not text:
+        return
     if isinstance(text, str):
         return text.encode("utf-8", errors="ignore").decode("utf-8")
     return text

--- a/debug_gym/gym/utils.py
+++ b/debug_gym/gym/utils.py
@@ -16,7 +16,7 @@ def clean_code(code):
 def filter_non_utf8(text):
     """Filter out non-UTF-8 characters from text."""
     if not text:
-        return
+        return None
     if isinstance(text, str):
         return text.encode("utf-8", errors="ignore").decode("utf-8")
     return text

--- a/debug_gym/llms/anthropic.py
+++ b/debug_gym/llms/anthropic.py
@@ -141,7 +141,7 @@ class AnthropicLLM(LLM):
                 {
                     "role": "user",
                     "content": filter_non_utf8(
-                        f"{history_info.step_observation.observation}"
+                        history_info.step_observation.observation
                     ),
                 }
             )
@@ -155,7 +155,7 @@ class AnthropicLLM(LLM):
                             "type": "tool_result",
                             "tool_use_id": history_info.action.id,  # 'toolu_01SdR84CsnTKRpdH4zwFjvGj'
                             "content": filter_non_utf8(
-                                f"{history_info.step_observation.observation}"
+                                history_info.step_observation.observation
                             ),  # 'Viewing `hangman_test.py`. The file is read-only, it is not editable.'
                         }
                     ],

--- a/debug_gym/llms/base.py
+++ b/debug_gym/llms/base.py
@@ -413,4 +413,9 @@ class LLM(ABC):
                 "Tool response is empty. The model may not have called a tool."
             )
 
+        print_messages(messages, self.logger)
+        self.logger.info(
+            f"LLM response - reasoning: {llm_response.response}\n"
+            f"LLM response - tool call: {llm_response.tool}"
+        )
         return llm_response

--- a/debug_gym/llms/openai.py
+++ b/debug_gym/llms/openai.py
@@ -171,7 +171,7 @@ class OpenAILLM(LLM):
                             },
                         },
                     ],
-                    "content": filter_non_utf8(f"{response[0].response}"),
+                    "content": filter_non_utf8(response[0].response),
                 }
             )
         if history_info.action is None:
@@ -180,7 +180,7 @@ class OpenAILLM(LLM):
                 {
                     "role": "user",
                     "content": filter_non_utf8(
-                        f"{history_info.step_observation.observation}"
+                        history_info.step_observation.observation
                     ),
                 }
             )
@@ -192,7 +192,7 @@ class OpenAILLM(LLM):
                     "tool_call_id": history_info.action.id,
                     "name": history_info.action.name,
                     "content": filter_non_utf8(
-                        f"{history_info.step_observation.observation}"
+                        history_info.step_observation.observation
                     ),
                 }
             )

--- a/debug_gym/llms/utils.py
+++ b/debug_gym/llms/utils.py
@@ -9,7 +9,6 @@ def print_messages(messages: list[dict], logger: DebugGymLogger):
         cyan: user messages
         yellow: system message
     """
-
     for m in messages:
         role = m["role"]
         if role == "tool":
@@ -20,16 +19,20 @@ def print_messages(messages: list[dict], logger: DebugGymLogger):
                     if item["type"] == "tool_result":
                         log_with_color(logger, str(item["content"]), "magenta")
                     else:
-                        log_with_color(logger, str(item), "cyan")
+                        log_with_color(logger, str(item), "magenta")
             else:
-                log_with_color(logger, str(m["content"]), "cyan")
+                log_with_color(logger, str(m["content"]), "magenta")
         elif role == "assistant":
-            content = m.get("content", m.get("tool_calls", m))
-            if isinstance(content, list):
-                for item in content:
-                    log_with_color(logger, str(item), "cyan")
-            else:
-                log_with_color(logger, str(content), "cyan")
+            content = m.get("content")
+            if content:
+                if isinstance(content, list):
+                    for item in content:
+                        log_with_color(logger, str(item), "cyan")
+                else:
+                    log_with_color(logger, str(content), "cyan")
+            if "tool_calls" in m:
+                for tool_call in m["tool_calls"]:
+                    log_with_color(logger, f"Tool call: {tool_call}", "cyan")
         elif role == "system":
             log_with_color(logger, str(m["content"]), "yellow")
         else:

--- a/debug_gym/llms/utils.py
+++ b/debug_gym/llms/utils.py
@@ -30,8 +30,9 @@ def print_messages(messages: list[dict], logger: DebugGymLogger):
                         log_with_color(logger, str(item), "cyan")
                 else:
                     log_with_color(logger, str(content), "cyan")
-            if "tool_calls" in m:
-                for tool_call in m["tool_calls"]:
+            tool_calls = m.get("tool_calls")
+            if tool_calls:
+                for tool_call in tool_calls:
                     log_with_color(logger, f"Tool call: {tool_call}", "cyan")
         elif role == "system":
             log_with_color(logger, str(m["content"]), "yellow")

--- a/debug_gym/llms/utils.py
+++ b/debug_gym/llms/utils.py
@@ -30,9 +30,6 @@ def print_messages(messages: list[dict], logger: DebugGymLogger):
                     log_with_color(logger, str(item), "cyan")
             else:
                 log_with_color(logger, str(content), "cyan")
-        elif role == "assistant":
-            content = m.get("content", m.get("tool_calls", m))
-            log_with_color(logger, str(content), "green")
         elif role == "system":
             log_with_color(logger, str(m["content"]), "yellow")
         else:

--- a/debug_gym/llms/utils.py
+++ b/debug_gym/llms/utils.py
@@ -12,7 +12,7 @@ def print_messages(messages: list[dict], logger: DebugGymLogger):
     for m in messages:
         role = m["role"]
         if role == "tool":
-            log_with_color(logger, m["content"], "magenta")
+            log_with_color(logger, m["content"], "green")
         elif role == "user":
             if isinstance(m["content"], list):
                 for item in m["content"]:

--- a/debug_gym/logger.py
+++ b/debug_gym/logger.py
@@ -363,12 +363,17 @@ class OverallProgressContext:
         """Refresh the progress display, updating overall and tasks progress."""
         # Update overall progress with new stats
         stats = self.tasks_progress.get_task_stats()
+        resolved = stats["resolved"] + stats["skip-resolved"]
+        unresolved = stats["unresolved"] + stats["skip-unresolved"] + stats["error"]
+        total_so_far = (resolved + unresolved) or 1  # Avoid division by zero
+        perf_so_far = f"{100. * float(resolved) / (total_so_far):.2f}%"
         stats_text = (
             f"running: [blue]{stats['running']}[/blue] | "
             f"pending: [yellow]{stats['pending']}[/yellow] | "
             f"resolved: [green]{stats['resolved'] + stats['skip-resolved']}[/green] | "
             f"unresolved: [red]{stats['unresolved'] + stats['skip-unresolved']}[/red] | "
-            f"error: [red]{stats['error']}[/red]"
+            f"error: [red]{stats['error']}[/red] | "
+            f"acc: [green]{perf_so_far}[/green]"
         )
         self.overall_progress.update(
             self._overall_task,

--- a/tests/gym/test_utils.py
+++ b/tests/gym/test_utils.py
@@ -608,7 +608,7 @@ def test_filter_non_utf8():
     assert filter_non_utf8(mixed_text) == mixed_text
 
     # Test with empty string
-    assert filter_non_utf8("") == ""
+    assert filter_non_utf8("") == None
 
     # Test with non-string input (should return as-is)
     assert filter_non_utf8(None) is None
@@ -656,10 +656,10 @@ def test_filter_non_utf8_edge_cases():
         (42, 42),
         (3.14, 3.14),
         (True, True),
-        (False, False),
-        ([], []),
-        ({}, {}),
-        (set(), set()),
+        (False, None),
+        ([], None),
+        ({}, None),
+        (set(), None),
     ]
 
     for input_val, expected in test_cases:

--- a/tests/llms/test_utils.py
+++ b/tests/llms/test_utils.py
@@ -3,28 +3,31 @@ from debug_gym.llms.utils import print_messages
 
 def test_print_messages(logger_mock):
     messages = [
-        {"role": "user", "content": "Hello"},
-        {"role": "assistant", "content": "Hi"},
         {"role": "system", "content": "System message"},
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "content": "Hi",
+            "tool_calls": ["Tool call 1", "Tool call 2"],
+        },
         {"role": "tool", "content": "Tool message"},
         {
             "role": "user",
             "content": [{"type": "tool_result", "content": "Tool result"}],
         },
-        {"role": "assistant", "tool_calls": ["Tool call 1", "Tool call 2"]},
-        {"role": "assistant", "tool_calls": "Single tool call"},
+        {"role": "assistant", "tool_calls": [{"key": 3, "key2": "value"}]},
         {"role": "system", "content": 12345},
     ]
     print_messages(messages, logger_mock)
     assert logger_mock._log_history == [
-        "[cyan]Hello[/cyan]",
-        "[cyan]Hi[/cyan]",
         "[yellow]System message[/yellow]",
-        "[magenta]Tool message[/magenta]",
+        "[magenta]Hello[/magenta]",
+        "[cyan]Hi[/cyan]",
+        "[cyan]Tool call: Tool call 1[/cyan]",
+        "[cyan]Tool call: Tool call 2[/cyan]",
+        "[green]Tool message[/green]",
         "[magenta]Tool result[/magenta]",
-        "[cyan]Tool call 1[/cyan]",
-        "[cyan]Tool call 2[/cyan]",
-        "[cyan]Single tool call[/cyan]",
+        "[cyan]Tool call: {'key': 3, 'key2': 'value'}[/cyan]",
         "[yellow]12345[/yellow]",
     ]
 


### PR DESCRIPTION
- content None was being stored as 'None' (a string in the messages)
- printing tool calls was broken if content was not None, eg 'None', so tool calls weren't printed
- use the same color for every role