### PR TITLE
Fix Skip

### DIFF
--- a/debug_gym/logger.py
+++ b/debug_gym/logger.py
@@ -253,7 +253,8 @@ class TaskProgressManager:
                     f" task {task.problem_id}.",
                     TaskProgress.color(task.status),
                 )
-                self.dump_task_status(task)
+                if task.status not in ["skip-resolved", "skip-unresolved"]:
+                    self.dump_task_status(task)
             # Update the Rich task
             pid = self._progress_task_ids.get(task.problem_id)
             if pid is not None:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -62,8 +62,7 @@ def run_agent(args, problem, config):
         if (
             not args.force_all
             and previous_run is not None
-            and previous_run.status
-            in ["resolved", "skip-resolved", "unresolved", "skip-unresolved"]
+            and previous_run.status in ["resolved", "unresolved"]
         ):
             task_logger.debug(f"Previous run found: {problem_path}")
             success = previous_run.status in ["resolved", "skip-resolved"]

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -65,7 +65,7 @@ def run_agent(args, problem, config):
             and previous_run.status in ["resolved", "unresolved"]
         ):
             task_logger.debug(f"Previous run found: {problem_path}")
-            success = previous_run.status in ["resolved", "skip-resolved"]
+            success = previous_run.status == "resolved"
             task_logger.debug(f"Previous run status: {previous_run.status}")
             if not args.force_failed or success:
                 status = "skip-resolved" if success else "skip-unresolved"

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -58,8 +58,13 @@ def run_agent(args, problem, config):
         mode="w" if args.force_all else "a",
     )
     try:
-        previous_run = load_previous_run_status(exp_path, problem)
-        if not args.force_all and previous_run is not None:
+        previous_run = load_previous_run_status(problem_path, problem)
+        if (
+            not args.force_all
+            and previous_run is not None
+            and previous_run.status
+            in ["resolved", "skip-resolved", "unresolved", "skip-unresolved"]
+        ):
             task_logger.debug(f"Previous run found: {problem_path}")
             success = previous_run.status in ["resolved", "skip-resolved"]
             task_logger.debug(f"Previous run status: {previous_run.status}")
@@ -72,7 +77,6 @@ def run_agent(args, problem, config):
                     score=previous_run.score,
                     max_score=previous_run.max_score,
                     status=status,
-                    logdir=previous_run.logdir,
                 )
                 task_logger.debug(f"Skipping {problem}, already done.")
                 return success


### PR DESCRIPTION
Fix a set of bugs in the skipping logic. Now it only skips `"resolved", "skip-resolved", "unresolved", "skip-unresolved"`.