### PR TITLE
remove unescape

### DIFF
--- a/debug_gym/gym/tools/rewrite.py
+++ b/debug_gym/gym/tools/rewrite.py
@@ -3,7 +3,6 @@ import difflib
 from debug_gym.gym.entities import Event, Observation
 from debug_gym.gym.tools.tool import EnvironmentTool
 from debug_gym.gym.tools.toolbox import Toolbox
-from debug_gym.gym.utils import clean_code
 
 
 @Toolbox.register()
@@ -45,7 +44,6 @@ class RewriteTool(EnvironmentTool):
 
     def _rewrite_file(self, environment, file_path, start, end, new_code):
         original_content = environment.read_file(file_path)
-        new_code = clean_code(new_code)  # str
         new_code_lines = new_code.split("\n")
         new_code_length = len(new_code_lines)
 

--- a/debug_gym/gym/utils.py
+++ b/debug_gym/gym/utils.py
@@ -6,13 +6,6 @@ from pathlib import Path
 from typing import Any, Callable
 
 
-def clean_code(code):
-    assert isinstance(code, str)
-    code_line = unescape(code).split("\n")
-    # Remove trailing white spaces with rstrip.
-    return "\n".join(line.rstrip() for line in code_line)
-
-
 def filter_non_utf8(text):
     """Filter out non-UTF-8 characters from text."""
     if not text:
@@ -20,20 +13,6 @@ def filter_non_utf8(text):
     if isinstance(text, str):
         return text.encode("utf-8", errors="ignore").decode("utf-8")
     return text
-
-
-def unescape(s):
-    try:
-        # First, try the normal unescape
-        result = codecs.decode(s, "unicode_escape")
-        # Test if it can be encoded to UTF-8 (which will happen during JSON encoding)
-        result.encode("utf-8")
-        return result
-    except UnicodeEncodeError:
-        # If it contains surrogate pairs that can't be encoded to UTF-8,
-        # replace them with the Unicode replacement character (U+FFFD)
-        result = codecs.decode(s, "unicode_escape")
-        return result.encode("utf-8", errors="replace").decode("utf-8")
 
 
 def show_line_number(code_string, code_path=None, environment=None, start_index=1):

--- a/tests/gym/test_utils.py
+++ b/tests/gym/test_utils.py
@@ -5,7 +5,6 @@ import pytest
 from debug_gym.gym.envs.env import RepoEnv
 from debug_gym.gym.utils import (
     _walk,
-    clean_code,
     cleanup_pytest_output,
     create_ignore_file,
     extract_max_score_from_pytest_output,
@@ -15,22 +14,7 @@ from debug_gym.gym.utils import (
     is_subdirectory,
     make_file_matcher,
     show_line_number,
-    unescape,
 )
-
-
-@pytest.mark.parametrize(
-    "code, expected",
-    [
-        ("def foo():    \n    return 42    \n", "def foo():\n    return 42\n"),
-        ("", ""),
-        ("def foo():\n    return 42", "def foo():\n    return 42"),
-        ("def foo():    \n    return 42    \n\n", "def foo():\n    return 42\n\n"),
-        ("def foo():\\n    return 42\\n", "def foo():\n    return 42\n"),
-    ],
-)
-def test_clean_code(code, expected):
-    assert clean_code(code) == expected
 
 
 def test_show_line_number_empty_code_string():
@@ -567,25 +551,6 @@ def test_walk():
     path_list.sort()
     expected.sort()
     assert path_list == expected
-
-
-def test_unescape_surrogate_pairs():
-    # Test with regular string
-    regular_string = "This is a regular string with escapes \\n\\t"
-    assert unescape(regular_string) == "This is a regular string with escapes \n\t"
-
-    # Test with surrogate pairs that would cause UTF-8 encoding issues
-    surrogate_string = "Test with surrogate \\ud800\\udc00 pair"
-    result = unescape(surrogate_string)
-
-    # Verify we can encode the result to UTF-8 without errors
-    try:
-        result.encode("utf-8")
-    except UnicodeEncodeError:
-        assert False, "Unescaped string still has invalid surrogate pairs"
-
-    # The result should replace the surrogate with a replacement character
-    assert "Test with surrogate" in result
 
 
 def test_filter_non_utf8():


### PR DESCRIPTION
This pull request removes the `clean_code` and `unescape` utility functions from the codebase, along with their associated tests and usages. These functions are no longer needed, and their removal simplifies the utilities module and related code.

**Code cleanup and simplification:**

* Removed the `clean_code` and `unescape` functions from `debug_gym/gym/utils.py`, as well as their imports and all usages throughout the codebase. [[1]](diffhunk://#diff-28bdc89cbc7200ada9728e0f0116be68667ecc005a86f79ad4fb9873d78d287eL9-L15) [[2]](diffhunk://#diff-28bdc89cbc7200ada9728e0f0116be68667ecc005a86f79ad4fb9873d78d287eL25-L38) [[3]](diffhunk://#diff-8838d43c3e93d1ca01c298221440bca4dfbc6f33c3eacd7b29926ca75e886f62L6) [[4]](diffhunk://#diff-8838d43c3e93d1ca01c298221440bca4dfbc6f33c3eacd7b29926ca75e886f62L48) [[5]](diffhunk://#diff-8fe9b7007890dd34347c5caf973a6d362105712372ec557125e3303b8e453528L8)
* Deleted all related tests for `clean_code` and `unescape` from `tests/gym/test_utils.py`. [[1]](diffhunk://#diff-8fe9b7007890dd34347c5caf973a6d362105712372ec557125e3303b8e453528L18-L35) [[2]](diffhunk://#diff-8fe9b7007890dd34347c5caf973a6d362105712372ec557125e3303b8e453528L572-L590)