### PR TITLE
Make pdb tool more robust when pdb fails to start

### DIFF
--- a/debug_gym/gym/terminal.py
+++ b/debug_gym/gym/terminal.py
@@ -98,6 +98,10 @@ class ShellSession:
         # Read the output until the sentinel or PS1
         output = self.read(read_until=read_until)
 
+        if not self.is_running:
+            self.close()
+            raise RuntimeError(f"{self} failed to start. Output:\n{output}")
+
         # Run session commands after starting the session if command was not provided
         if not command and self.session_commands:
             command = " && ".join(self.session_commands)

--- a/debug_gym/gym/tools/pdb.py
+++ b/debug_gym/gym/tools/pdb.py
@@ -89,7 +89,8 @@ class PDBTool(EnvironmentTool):
 
         if "The program finished and will be restarted" in initial_output:
             self.close_pdb()
-        else:
+
+        if self.pdb_is_running:
             if environment.persistent_breakpoints:
                 # restore persistent breakpoints
                 for _, _command in environment.current_breakpoints_state.items():
@@ -98,7 +99,9 @@ class PDBTool(EnvironmentTool):
                     initial_output = "\n".join(
                         [initial_output, "Breakpoints have been restored."]
                     )
+
             self.set_current_frame_file(environment)
+
         return initial_output
 
     def on_env_reset(self, environment, **kwargs) -> Observation:


### PR DESCRIPTION
This pull request introduces improved error handling and logic updates for starting terminal and PDB sessions in the `debug_gym` package. The main changes ensure that sessions are properly closed and errors are raised when startup fails, and that persistent breakpoints are only restored when the PDB session is running.

**Error handling improvements:**

* In `gym/terminal.py`, the `start` method now closes the session and raises a `RuntimeError` if the terminal fails to start, providing the output for debugging.

**PDB session logic updates:**

* In `gym/tools/pdb.py`, persistent breakpoints are now restored only if the PDB session is confirmed to be running, preventing unnecessary operations.
* After restoring breakpoints, the current frame file is set to ensure correct debugging context.