### PR TITLE
Invert check terminal logic: FORCE_DOCKER_TERMINAL -> ALLOW_LOCAL_TERMINAL

### DIFF
--- a/.github/actions/test-if-changes/action.yml
+++ b/.github/actions/test-if-changes/action.yml
@@ -26,7 +26,7 @@ runs:
         pip install -e '.[dev]'
     - name: Run tests
       env:
-        FORCE_DOCKER_TERMINAL: false
+        ALLOW_LOCAL_TERMINAL: true
       shell: bash
       run: |
         DEBUG_GYM_DEBUG=1 pytest ${{ inputs.test-files }} -vv -n 16 --timeout=600 --cov=debug_gym --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           pip install -e '.[dev]'
       - name: Test - PR - Fast
         env:
-          FORCE_DOCKER_TERMINAL: false
+          ALLOW_LOCAL_TERMINAL: true
         run: |
           DEBUG_GYM_DEBUG=1 pytest -vv -n 16 -k "not test_swe_bench and not test_swe_smith and not test_r2egym" --cov=debug_gym --cov-report=term-missing --timeout=600
       - name: Store coverage report

--- a/debug_gym/gym/tools/bash.py
+++ b/debug_gym/gym/tools/bash.py
@@ -31,19 +31,17 @@ class BashTool(EnvironmentTool):
     def use(self, environment, command: str) -> Observation:
         """Execute a bash command in the environment's terminal and return the result."""
         try:
-            # Assert that the terminal is a Docker terminal (only in production)
+            # Assert that the terminal is not a local terminal (only in production)
             import os
 
-            from debug_gym.gym.terminals.docker import DockerTerminal
+            from debug_gym.gym.terminals.terminal import Terminal
 
-            # Skip Docker terminal check during testing or when explicitly disabled
-            require_docker = (
-                os.getenv("FORCE_DOCKER_TERMINAL", "true").lower() == "true"
-            )
-            if require_docker and not isinstance(environment.terminal, DockerTerminal):
+            # Allow local terminal when explicitly enabled
+            allow_local = os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "true"
+            if not allow_local and type(environment.terminal) is Terminal:
                 return Observation(
                     self.name,
-                    "Error: bash tool requires a Docker terminal. Current terminal type is not supported.",
+                    "Error: bash tool requires a non-local terminal. Current terminal type is not supported.",
                 )
 
             # Use the environment's terminal to run the command

--- a/debug_gym/gym/tools/bash.py
+++ b/debug_gym/gym/tools/bash.py
@@ -36,9 +36,11 @@ class BashTool(EnvironmentTool):
 
             from debug_gym.gym.terminals.terminal import Terminal
 
-            # Allow local terminal when explicitly enabled
-            allow_local = os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "true"
-            if not allow_local and type(environment.terminal) is Terminal:
+            # Require remote terminal unless local is explicitly allowed
+            require_remote = (
+                os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "false"
+            )
+            if require_remote and type(environment.terminal) is Terminal:
                 return Observation(
                     self.name,
                     "Error: bash tool requires a non-local terminal. Current terminal type is not supported.",

--- a/debug_gym/gym/tools/bash.py
+++ b/debug_gym/gym/tools/bash.py
@@ -38,7 +38,7 @@ class BashTool(EnvironmentTool):
 
             # Require remote terminal unless local is explicitly allowed
             require_remote = (
-                os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "false"
+                os.environ.get("ALLOW_LOCAL_TERMINAL", "false").lower() == "false"
             )
             if require_remote and type(environment.terminal) is Terminal:
                 return Observation(

--- a/debug_gym/gym/tools/grep.py
+++ b/debug_gym/gym/tools/grep.py
@@ -93,9 +93,11 @@ class GrepTool(EnvironmentTool):
 
             from debug_gym.gym.terminals.terminal import Terminal
 
-            # Allow local terminal when explicitly enabled
-            allow_local = os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "true"
-            if not allow_local and type(environment.terminal) is Terminal:
+            # Require remote terminal unless local is explicitly allowed
+            require_remote = (
+                os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "false"
+            )
+            if require_remote and type(environment.terminal) is Terminal:
                 return Observation(
                     self.name,
                     "Error: grep tool requires a non-local terminal. Current terminal type is not supported.",

--- a/debug_gym/gym/tools/grep.py
+++ b/debug_gym/gym/tools/grep.py
@@ -95,7 +95,7 @@ class GrepTool(EnvironmentTool):
 
             # Require remote terminal unless local is explicitly allowed
             require_remote = (
-                os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "false"
+                os.environ.get("ALLOW_LOCAL_TERMINAL", "false").lower() == "false"
             )
             if require_remote and type(environment.terminal) is Terminal:
                 return Observation(

--- a/debug_gym/gym/tools/grep.py
+++ b/debug_gym/gym/tools/grep.py
@@ -88,19 +88,17 @@ class GrepTool(EnvironmentTool):
             command += f" | head -{max_results}"
 
         try:
-            # Assert that the terminal is a Docker terminal (only in production)
+            # Assert that the terminal is not a local terminal (only in production)
             import os
 
-            from debug_gym.gym.terminals.docker import DockerTerminal
+            from debug_gym.gym.terminals.terminal import Terminal
 
-            # Skip Docker terminal check during testing or when explicitly disabled
-            require_docker = (
-                os.getenv("FORCE_DOCKER_TERMINAL", "true").lower() == "true"
-            )
-            if require_docker and not isinstance(environment.terminal, DockerTerminal):
+            # Allow local terminal when explicitly enabled
+            allow_local = os.getenv("ALLOW_LOCAL_TERMINAL", "false").lower() == "true"
+            if not allow_local and type(environment.terminal) is Terminal:
                 return Observation(
                     self.name,
-                    "Error: grep tool requires a Docker terminal. Current terminal type is not supported.",
+                    "Error: grep tool requires a non-local terminal. Current terminal type is not supported.",
                 )
 
             # Use the environment's terminal to run the grep command


### PR DESCRIPTION
This pull request updates the terminal environment checks for bash and grep tools, switching from requiring a Docker terminal to requiring a non-local terminal by default. It also changes the corresponding environment variable from `FORCE_DOCKER_TERMINAL` to `ALLOW_LOCAL_TERMINAL` in both the codebase and CI configuration files.