### PR TITLE
Chunk very long commands when writing file.

### DIFF
--- a/debug_gym/logger.py
+++ b/debug_gym/logger.py
@@ -518,7 +518,12 @@ class DebugGymLogger(logging.Logger):
     ):
         super().__init__(name)
         # If var env "DEBUG_GYM_DEBUG" is set, turn on debug mode
-        if os.environ.get("DEBUG_GYM_DEBUG"):
+        if os.environ.get("DEBUG_GYM_DEBUG", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        ):
             level = logging.DEBUG
 
         # Prevent the log messages from being propagated to the root logger

--- a/tests/gym/test_workspace.py
+++ b/tests/gym/test_workspace.py
@@ -312,3 +312,13 @@ def test_write_file(workspace):
     file_content_with_newlines = "Hello, DebugGym!\nThis is a test.\n"
     workspace.write_file("test.txt", file_content_with_newlines)
     assert file_path.read_text() == file_content_with_newlines
+
+    # Test with empty content
+    file_content_empty = ""
+    workspace.write_file("test.txt", file_content_empty)
+    assert file_path.read_text() == file_content_empty
+
+    # Test with content exceeding max command length.
+    file_content_exceeding_max_command_length = "A" * (2 * 1024**2)  # 2MB of 'A's
+    workspace.write_file("test.txt", file_content_exceeding_max_command_length)
+    assert file_path.read_text() == file_content_exceeding_max_command_length


### PR DESCRIPTION
This pull request introduces improvements to file writing in the workspace and enhances the logger's debug mode activation. The most significant changes are the addition of chunked file writing to handle large contents, more robust detection of debug mode via environment variables, and expanded test coverage for edge cases in file writing.

**Workspace file writing improvements:**

* The `write_file` method in `debug_gym/gym/workspace.py` now splits content into 32kB chunks when writing to files, ensuring compatibility with shell command length limits and supporting very large files.

**Logger enhancements:**

* The debug mode in `debug_gym/logger.py` is now activated if the `DEBUG_GYM_DEBUG` environment variable matches common truthy values like `"1"`, `"true"`, `"yes"`, or `"on"`, making it more flexible and user-friendly.

**Test coverage improvements:**

* The test `test_write_file` in `tests/gym/test_workspace.py` now includes checks for writing empty content and very large content (2MB), verifying that the new chunked writing logic works correctly for these edge cases.

Closes #245 

