### PR TITLE
Clean space in GA runner

### DIFF
--- a/.github/actions/test-if-changes/action.yml
+++ b/.github/actions/test-if-changes/action.yml
@@ -22,6 +22,14 @@ runs:
       with:
         python-version: '3.12'
         cache: 'pip'
+    - name: Free disk space before dependency installation
+      shell: bash
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+        docker system prune -af
+        sudo apt-get clean
+        df -h
     - name: Install dependencies
       shell: bash
       run: |


### PR DESCRIPTION
This pull request adds a step to free up disk space before installing dependencies in the GitHub Actions workflow. This helps ensure that there is enough space for the installation process, especially in environments with limited storage.

Workflow improvements:

* Added a step to remove unused packages and clean up disk space (removing `.NET`, `GHC`, `Boost`, unused Docker images, and cleaning `apt-get` cache) before dependency installation in the `.github/actions/test-if-changes/action.yml` workflow.