### PR TITLE
Fix Kube double reservation

### DIFF
--- a/debug_gym/gym/terminals/kubernetes.py
+++ b/debug_gym/gym/terminals/kubernetes.py
@@ -518,7 +518,8 @@ class KubernetesTerminal(Terminal):
                             "stdinOnce": False,
                             "tty": True,
                             "env": [
-                                {"name": k, "value": v} for k, v in self.env_vars.items()
+                                {"name": k, "value": v}
+                                for k, v in self.env_vars.items()
                             ],
                             "resources": {
                                 "requests": {"cpu": "0.5", "memory": "1Gi"},


### PR DESCRIPTION
This pull request introduces improved handling of Kubernetes pod creation failures due to sandbox reservation conflicts in the `debug_gym/gym/terminals/kubernetes.py` module. The main changes include a new error type for sandbox reservation conflicts, periodic checking for these errors while waiting for a pod to become ready, and automatic retries with new pod names if a conflict is detected.

-- Attempt to solve

Warning FailedCreatePodSandBox 5s (x7 over 72s) kubelet Failed to create pod sandbox: rpc error: code = Unknown desc = failed to reserve sandbox name "dbg-gym.django--django-13821.f6085e6a_mtl-eval_95514fde-ef27-4ef3-a483-ff3e9b242363_0": name "dbg-gym.django--django-13821.f6085e6a_mtl-eval_95514fde-ef27-4ef3-a483-ff3e9b242363_0" is reserved for "ee394b275dbba2253a6e61398e15baa391baf59f5ed884d5257f594db17e0de3"