### PR TITLE
Make sure we reset the tests before running the evaluation

### DIFF
--- a/debug_gym/gym/envs/swe_bench.py
+++ b/debug_gym/gym/envs/swe_bench.py
@@ -166,13 +166,23 @@ class SWEBenchEnv(RepoEnv):
         )
         self.logger.debug(f"fail_to_pass: {self.fail_to_pass}")
         self.logger.debug(f"Test status map: {test_status_map}")
-        score = sum(
+        f2p_score = sum(
             1
             for test in self.fail_to_pass
             # *Do not* assume silent success for now as done in SWE-Bench grading.py
             if test_status_map.get(test, TestStatus.ERROR.value)
             in (TestStatus.PASSED.value, TestStatus.XFAIL.value)
         )
+        p2p_score = sum(
+            1
+            for test in self.pass_to_pass
+            if test_status_map.get(test, TestStatus.PASSED.value)
+            in (TestStatus.PASSED.value, TestStatus.XFAIL.value)
+        )
+
+        # The final score is f2p_score only if all pass_to_pass tests passed.
+        score = f2p_score if p2p_score == len(self.pass_to_pass) else 0
+
         assert score <= self.max_score
         return score
 

--- a/debug_gym/gym/envs/swe_smith.py
+++ b/debug_gym/gym/envs/swe_smith.py
@@ -113,7 +113,7 @@ class SWESmithEnv(SWEBenchEnv):
 
     def calculate_score(self, eval_output: EvalOutput) -> int:
         test_status_map = self.log_parser(eval_output.output)
-        score = sum(
+        f2p_score = sum(
             1
             for test in self.fail_to_pass
             # *Do not* assume silent success for now as done in SWE-Smith grading.py
@@ -121,6 +121,15 @@ class SWESmithEnv(SWEBenchEnv):
             if test_status_map.get(test, TestStatus.ERROR.value)
             in (TestStatus.PASSED.value, TestStatus.XFAIL.value)
         )
+        p2p_score = sum(
+            1
+            for test in self.pass_to_pass
+            if test_status_map.get(test, TestStatus.PASSED.value)
+            in (TestStatus.PASSED.value, TestStatus.XFAIL.value)
+        )
+
+        # The final score is f2p_score only if all pass_to_pass tests passed.
+        score = f2p_score if p2p_score == len(self.pass_to_pass) else 0
 
         # Getting not passed tests.
         not_passed_tests = {


### PR DESCRIPTION
This pull request updates the scoring logic in both the `swe_bench` and `swe_smith` environments to ensure that fail-to-pass tests only contribute to the score if all pass-to-pass tests are successful. Additionally, it introduces a reset step for test directive files before evaluation in `swe_smith`. These changes make the scoring more robust and the evaluation process more reliable.

### Scoring logic improvements

* Updated `calculate_score` in both `swe_bench.py` and `swe_smith.py` to require that all `pass_to_pass` tests pass before awarding points for `fail_to_pass` tests, making the scoring stricter and more accurate. [[1]](diffhunk://#diff-14c661bab81e165fba55704ca88ccbf72e3a1a1f5c528ff9857527106d3f34ddL169-R185) [[2]](diffhunk://#diff-dc23c08d05edaeab65b40bf7c47817882fcf7469572cb67b26973049578cda7dL116-R132)

### Evaluation reliability

* Added a step in `swe_smith.py` to reset changes to `test_directives` files using `git checkout` before running the evaluation, ensuring a clean test environment for each run.