### PR TITLE
X session

### DIFF
--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -186,6 +186,7 @@ def run_task(args, problem, config):
         )
 
         env = create_env(config, task_logger)
+        # X-Session-ID enables consistent-hash routing in vllm-router
         llm = LLM.instantiate(
             **config.get("llm", {}),
             logger=task_logger,

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -186,7 +186,11 @@ def run_task(args, problem, config):
         )
 
         env = create_env(config, task_logger)
-        llm = LLM.instantiate(**config.get("llm", {}), logger=task_logger)
+        llm = LLM.instantiate(
+            **config.get("llm", {}),
+            logger=task_logger,
+            extra_headers={"X-Session-ID": problem},
+        )
         agent = create_agent(config["agent"], logger=task_logger)
 
         try:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -107,6 +107,7 @@ def run_agent(args, task_name: str, task_data: dict, config: dict):
                     )
 
                 env = create_env(config, task_data, task_logger)
+                # X-Session-ID enables consistent-hash routing in vllm-router
                 llm = LLM.instantiate(
                     **config.get("llm", {}),
                     logger=task_logger,

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -107,7 +107,11 @@ def run_agent(args, task_name: str, task_data: dict, config: dict):
                     )
 
                 env = create_env(config, task_data, task_logger)
-                llm = LLM.instantiate(**config.get("llm", {}), logger=task_logger)
+                llm = LLM.instantiate(
+                    **config.get("llm", {}),
+                    logger=task_logger,
+                    extra_headers={"X-Session-ID": task_name},
+                )
                 agent = create_agent(
                     config.get("agent", {}), llm=llm, logger=task_logger
                 )


### PR DESCRIPTION
This pull request introduces support for passing a custom `X-Session-ID` header to the LLM instantiation process in both the `run.py` and `replay.py` scripts, enabling consistent-hash routing in the `vllm-router`.