### PR TITLE
Configurable Timeout Argument to BashTool

### DIFF
--- a/debug_gym/gym/tools/bash.py
+++ b/debug_gym/gym/tools/bash.py
@@ -11,13 +11,13 @@ class BashTool(EnvironmentTool):
     MAX_TIMEOUT = 3600  # 1 hour
 
     examples = [
-        """bash(command="ls -la") to list all files and directories with detailed information.""",
-        """bash(command="grep -r 'function_name' .") to search for 'function_name' in all files recursively.""",
-        """bash(command="find . -name '*.py' | head -10") to find Python files in the current directory.""",
-        """bash(command="cat file.txt | head -20") to show the first 20 lines of a file.""",
-        """bash(command="sed -n 10,25p path/to/file") to show lines 10 to 25 of a file at relative path.""",
-        """bash(command="pip list") to show installed Python packages.""",
-        """bash(command="python -m pytest tests/ -x", timeout=600) to run tests with a 10-minute timeout.""",
+        """Use bash with `command`: "ls -la" to list all files and directories with detailed information.""",
+        """Use bash with `command`: "grep -r 'function_name' ." to search for 'function_name' in all files recursively.""",
+        """Use bash with `command`: "find . -name '*.py' | head -10" to find Python files in the current directory.""",
+        """Use bash with `command`: "cat file.txt | head -20" to show the first 20 lines of a file.""",
+        """Use bash with `command`: "sed -n 10,25p path/to/file" to show lines 10 to 25 of a file at relative path.""",
+        """Use bash with `command`: "pip list" to show installed Python packages.""",
+        """Use bash with `command`: "python -m pytest tests/ -x" and `timeout`: 600 to run tests with a 10-minute timeout.""",
     ]
     description = (
         "Run commands in a bash shell. "

--- a/debug_gym/gym/tools/bash.py
+++ b/debug_gym/gym/tools/bash.py
@@ -7,6 +7,9 @@ from debug_gym.gym.tools.toolbox import Toolbox
 @Toolbox.register()
 class BashTool(EnvironmentTool):
     name: str = "bash"
+    DEFAULT_TIMEOUT = 30  # seconds
+    MAX_TIMEOUT = 3600  # 1 hour
+
     examples = [
         """bash(command="ls -la") to list all files and directories with detailed information.""",
         """bash(command="grep -r 'function_name' .") to search for 'function_name' in all files recursively.""",
@@ -14,6 +17,7 @@ class BashTool(EnvironmentTool):
         """bash(command="cat file.txt | head -20") to show the first 20 lines of a file.""",
         """bash(command="sed -n 10,25p path/to/file") to show lines 10 to 25 of a file at relative path.""",
         """bash(command="pip list") to show installed Python packages.""",
+        """bash(command="python -m pytest tests/ -x", timeout=600) to run tests with a 10-minute timeout.""",
     ]
     description = (
         "Run commands in a bash shell. "
@@ -27,9 +31,18 @@ class BashTool(EnvironmentTool):
             "type": ["string"],
             "description": "The bash command to execute. The command will be run in the current working directory of the environment.",
         },
+        "timeout": {
+            "type": ["integer", "null"],
+            "description": (
+                f"Maximum time in seconds for the command to run. "
+                f"Defaults to {DEFAULT_TIMEOUT}s if not specified. "
+                f"Maximum allowed value is {MAX_TIMEOUT}s (1 hour). "
+                f"Use longer timeouts for commands like test suites or builds."
+            ),
+        },
     }
 
-    def use(self, environment, command: str) -> Observation:
+    def use(self, environment, command: str, timeout: int = None) -> Observation:
         """Execute a bash command in the environment's terminal and return the result."""
         try:
             # Assert that the terminal is not a local terminal (only in production)
@@ -47,9 +60,13 @@ class BashTool(EnvironmentTool):
                     "Error: bash tool requires a non-local terminal. Current terminal type is not supported.",
                 )
 
-            # Use the environment's terminal to run the command
-            # Set a reasonable timeout (30 seconds) to prevent hanging
-            success, output = environment.terminal.run(command, timeout=30)
+            # Resolve timeout: use provided value, clamp to max, or fall back to default
+            if timeout is not None:
+                timeout = max(1, min(int(timeout), self.MAX_TIMEOUT))
+            else:
+                timeout = self.DEFAULT_TIMEOUT
+
+            success, output = environment.terminal.run(command, timeout=timeout)
 
             if success:
                 result = (

--- a/debug_gym/gym/tools/edit.py
+++ b/debug_gym/gym/tools/edit.py
@@ -11,11 +11,11 @@ from debug_gym.gym.workspace import WorkspaceReadError
 class EditTool(EnvironmentTool):
     name = "edit"
     examples = [
-        """edit(path=\"code/utils.py\", start=None, end=None, new_code=\"print('hola')\") will edit the specified file 'code/utils.py' (the entire code) to be print('hola'), because no line number is provided.""",
-        """edit(path=\"code/utils.py\", start=10, end=None, new_code=\"    print('bonjour')\") will edit line number 10 of the specified file 'code/utils.py' to be print('bonjour'), with the indents ahead (in this case, 4 spaces).""",
-        """edit(path=\"code/utils.py\", start=10, end=20, new_code=\"    print('hello')\\n    print('hi again')\") will replace the chunk of code between line number 10 and 20 in the specified file 'code/utils.py' by the two lines provided, both with indents ahead (in this case, 4 spaces).""",
-        """edit(path='code/utils.py', start=4, end=6, new_code=\"        print('buongiorno')\") will replace the chunk of code between line number 4 and 6 in the specified file 'code/utils.py' by the single line provided, with the indent ahead (in this case, 8 spaces).""",
-        """edit(path='code/new_utils.py', new_code=\"print('hello new file')\") will create 'code/new_utils.py' with the provided content when the file does not already exist.""",
+        """Use edit with `path`: "code/utils.py", `start`: null, `end`: null, and `new_code`: "print('hola')" to replace the entire content of 'code/utils.py' with print('hola'), because no line number is provided.""",
+        """Use edit with `path`: "code/utils.py", `start`: 10, `end`: null, and `new_code`: "    print('bonjour')" to replace line 10 of 'code/utils.py' with print('bonjour'), with 4 spaces of indentation.""",
+        """Use edit with `path`: "code/utils.py", `start`: 10, `end`: 20, and `new_code`: "    print('hello')\\n    print('hi again')" to replace lines 10-20 of 'code/utils.py' with the two lines provided, both with 4 spaces of indentation.""",
+        """Use edit with `path`: "code/utils.py", `start`: 4, `end`: 6, and `new_code`: "        print('buongiorno')" to replace lines 4-6 of 'code/utils.py' with a single line with 8 spaces of indentation.""",
+        """Use edit with `path`: "code/new_utils.py" and `new_code`: "print('hello new file')" to create a new file 'code/new_utils.py' with the provided content when the file does not already exist.""",
     ]
     description = (
         "Edit the content of the specified file path, between lines [start, end], with the new code. Line numbers are 1-based. When start is provided and end is None, it's assumed to edit a single line (start). When both start and end are None, it's assumed to edit the whole file, this is not recommended because most of the time the expected change is local. If the file does not exist yet, it will be created with the provided content. The new code should be valid python code include proper indentation (can be determined from context)."

--- a/debug_gym/gym/tools/grep.py
+++ b/debug_gym/gym/tools/grep.py
@@ -11,11 +11,11 @@ class GrepTool(EnvironmentTool):
     name: str = "grep"
 
     examples = [
-        """grep(pattern="function", path=None) to search for the word "function" in all files in the repository.""",
-        """grep(pattern="class.*Test", path="*.py") to search for lines matching the regex pattern "class.*Test" in all files under the 'tests/' directory.""",
-        """grep(pattern="import numpy", path="src/main.py") to search for "import numpy" in the specific file 'src/main.py'.""",
-        """grep(pattern="TODO") to search for "TODO".""",
-        """grep(pattern="bug", max_results=10) to search for "bug" and limit results to 10 matches.""",
+        """Use grep with `pattern`: "function" to search for the word "function" in all files in the repository.""",
+        """Use grep with `pattern`: "class.*Test" and `path`: "*.py" to search for lines matching the regex pattern "class.*Test" in all Python files.""",
+        """Use grep with `pattern`: "import numpy" and `path`: "src/main.py" to search for "import numpy" in the specific file 'src/main.py'.""",
+        """Use grep with `pattern`: "TODO" to search for "TODO" in all files.""",
+        """Use grep with `pattern`: "bug" and `max_results`: 10 to search for "bug" and limit results to 10 matches.""",
     ]
     description = (
         "Search for a pattern in files within the repository. Can search in specific files, directories, or the entire repository. "

--- a/debug_gym/gym/tools/listdir.py
+++ b/debug_gym/gym/tools/listdir.py
@@ -11,9 +11,9 @@ class ListdirTool(EnvironmentTool):
     setup_commands: tuple[str, ...] = ("apt-get update && apt-get install -y tree",)
 
     examples = [
-        """listdir(path=None, depth=None) to list the contents of the working directory.""",
-        """listdir(path="src/util", depth=None) to list the contents of the 'util' subdirectory within the 'src' subdirectory.""",
-        """listdir(path="src", depth=2) to list the contents of the 'src' subdirectory up to a depth of 2.""",
+        """Use listdir with `path`: null and `depth`: null to list the contents of the working directory.""",
+        """Use listdir with `path`: "src/util" and `depth`: null to list the contents of the 'util' subdirectory within the 'src' subdirectory.""",
+        """Use listdir with `path`: "src" and `depth`: 2 to list the contents of the 'src' subdirectory up to a depth of 2.""",
     ]
     description = (
         "List the file and folder contents of a subdirectory within the working directory, up to a specified 'depth' (default depth is 1). "

--- a/debug_gym/gym/tools/pdb.py
+++ b/debug_gym/gym/tools/pdb.py
@@ -12,11 +12,11 @@ from debug_gym.gym.tools.toolbox import Toolbox
 class PDBTool(EnvironmentTool):
     name: str = "pdb"
     examples = [
-        """pdb(command="b mttl/models/modifiers/mlp.py:42") to set a breakpoint at line 42 in the file with the path 'mttl/models/modifiers/mlp.py'.""",
-        """pdb(command="c") to continue the execution until the next breakpoint.""",
-        """pdb(command="p x") to print the value of the variable x in the current context.""",
-        """pdb(command="cl src/code.py:26") to clear the breakpoint at line 26 in the file 'src/code.py'.""",
-        """pdb(command="l", entrypoint="python -m pdb src/app.py") to list the source around the current frame after starting the PDB session for 'src/app.py'.""",
+        """Use pdb with `command`: "b mttl/models/modifiers/mlp.py:42" to set a breakpoint at line 42 in 'mttl/models/modifiers/mlp.py'.""",
+        """Use pdb with `command`: "c" to continue execution until the next breakpoint.""",
+        """Use pdb with `command`: "p x" to print the value of the variable x in the current context.""",
+        """Use pdb with `command`: "cl src/code.py:26" to clear the breakpoint at line 26 in 'src/code.py'.""",
+        """Use pdb with `command`: "l" and `entrypoint`: "python -m pdb src/app.py" to list the source around the current frame after starting a PDB session for 'src/app.py'.""",
     ]
     description = (
         "An interface to the Python debugger PDB. Send a command to the PDB terminal. The command should be a valid PDB command."

--- a/debug_gym/gym/tools/submit.py
+++ b/debug_gym/gym/tools/submit.py
@@ -6,7 +6,15 @@ from debug_gym.gym.tools.toolbox import Toolbox
 @Toolbox.register()
 class SubmitTool(EnvironmentTool):
     name = "submit"
-    description = "Should be called when the task is complete."
+    examples = [
+        """Use submit with `message`: "Fixed the off-by-one error in the loop condition" to submit the solution with a summary of the changes made.""",
+        """Use submit with `message`: null to submit without a message.""",
+    ]
+    description = (
+        "Should be called when the task is complete."
+        + "\nExamples (for demonstration purposes only, you need to adjust the tool calling format according to your specific syntax):\n"
+        + "\n".join(examples)
+    )
     arguments = {
         "message": {
             "type": ["string", "null"],

--- a/debug_gym/gym/tools/view.py
+++ b/debug_gym/gym/tools/view.py
@@ -10,11 +10,11 @@ from debug_gym.gym.workspace import WorkspaceReadError
 class ViewTool(EnvironmentTool):
     name: str = "view"
     examples = [
-        """view(path="main.py") to show the content of a file called 'main.py' in the root. The content will be annotated with line numbers and current breakpoints because include_line_numbers_and_breakpoints is True by default.""",
-        """view(path="utils/vector.py", include_line_numbers_and_breakpoints=True) to show the content of a file called 'vector.py' in a subdirectory called 'utils'. The content will be annotated with line numbers and current breakpoints.""",
-        """view(path="src/util.py", include_line_numbers_and_breakpoints=False) to show the content of a file called 'util.py' in a subdirectory called 'src'. The line numbers and breakpoints will not be included in the output.""",
-        """view(path="funcs/helper.py", start=6, end=24) to show the content of a file called 'helper.py' in a subdirectory called 'funcs', starting from line 6 to line 24. The content will be annotated with line numbers and current breakpoints.""",
-        """view(path="src/main.py", start=514) to show the content of a file called 'main.py' in a subdirectory called 'src', starting from line 514 to the end of the file. The content will be annotated with line numbers and current breakpoints.""",
+        """Use view with `path`: "main.py" to show the content of 'main.py' in the root. The content will be annotated with line numbers and current breakpoints because include_line_numbers_and_breakpoints is true by default.""",
+        """Use view with `path`: "utils/vector.py" and `include_line_numbers_and_breakpoints`: true to show the content of 'vector.py' in the 'utils' subdirectory, annotated with line numbers and current breakpoints.""",
+        """Use view with `path`: "src/util.py" and `include_line_numbers_and_breakpoints`: false to show the content of 'util.py' without line numbers or breakpoints.""",
+        """Use view with `path`: "funcs/helper.py", `start`: 6, and `end`: 24 to show lines 6 to 24 of 'helper.py', annotated with line numbers and current breakpoints.""",
+        """Use view with `path`: "src/main.py" and `start`: 514 to show the content of 'main.py' starting from line 514 to the end of the file.""",
     ]
     description = (
         "Specify a file path to view its content. The file path should be relative to the root directory of the repository."

--- a/tests/gym/tools/test_bash.py
+++ b/tests/gym/tools/test_bash.py
@@ -55,7 +55,9 @@ def test_bash_tool_metadata(bash_tool):
     assert bash_tool.name == "bash"
     assert "Run commands in a bash shell" in bash_tool.description
     assert "command" in bash_tool.arguments
+    assert "timeout" in bash_tool.arguments
     assert bash_tool.arguments["command"]["type"] == ["string"]
+    assert bash_tool.arguments["timeout"]["type"] == ["integer", "null"]
     assert len(bash_tool.examples) > 0
 
 
@@ -222,7 +224,7 @@ def test_bash_terminal_success(mock_run, bash_tool):
     assert result.source == "bash"
     assert result.observation == "Success output"
 
-    # Verify terminal.run was called with correct parameters
+    # Verify terminal.run was called with correct parameters (default timeout)
     mock_run.assert_called_once_with("echo hello", timeout=30)
 
 
@@ -489,3 +491,50 @@ def test_bash_file_creation_unicode_content(env):
     assert "世界" in observation
     assert "Привет мир" in observation
     assert "🎉" in observation
+
+
+@patch("debug_gym.gym.terminals.LocalTerminal.run")
+def test_bash_custom_timeout(mock_run, bash_tool):
+    """Test that a custom timeout is passed to terminal.run."""
+    mock_run.return_value = (True, "output")
+    mock_env = MagicMock()
+    mock_env.terminal = MagicMock()
+    mock_env.terminal.run = mock_run
+
+    bash_tool.use(mock_env, "pytest tests/", timeout=600)
+    mock_run.assert_called_once_with("pytest tests/", timeout=600)
+
+
+@patch("debug_gym.gym.terminals.LocalTerminal.run")
+def test_bash_timeout_clamped_to_max(mock_run, bash_tool):
+    """Test that timeout exceeding MAX_TIMEOUT is clamped."""
+    mock_run.return_value = (True, "output")
+    mock_env = MagicMock()
+    mock_env.terminal = MagicMock()
+    mock_env.terminal.run = mock_run
+
+    bash_tool.use(mock_env, "long_command", timeout=9999)
+    mock_run.assert_called_once_with("long_command", timeout=BashTool.MAX_TIMEOUT)
+
+
+@patch("debug_gym.gym.terminals.LocalTerminal.run")
+def test_bash_timeout_none_uses_default(mock_run, bash_tool):
+    """Test that timeout=None uses the default timeout."""
+    mock_run.return_value = (True, "output")
+    mock_env = MagicMock()
+    mock_env.terminal = MagicMock()
+    mock_env.terminal.run = mock_run
+
+    bash_tool.use(mock_env, "echo hi", timeout=None)
+    mock_run.assert_called_once_with("echo hi", timeout=BashTool.DEFAULT_TIMEOUT)
+
+
+def test_bash_with_timeout_via_env_step(env):
+    """Test passing timeout through env.step tool call."""
+    bash_call = ToolCall(
+        id="bash_test",
+        name="bash",
+        arguments={"command": "echo 'quick'", "timeout": 10},
+    )
+    env_info = env.step(bash_call)
+    assert "quick" in env_info.step_observation.observation


### PR DESCRIPTION
- LLM can now specify timeout per command: bash(command="pytest", timeout=600)
- Default timeout: 30s (unchanged from previous behavior)
- Maximum timeout: 3600s (1 hour), values above are clamped
- timeout=null uses the default
- Added 4 new tests for timeout behavior