### PR TITLE
Add configurable docker container resource limits

### DIFF
--- a/debug_gym/gym/terminals/docker.py
+++ b/debug_gym/gym/terminals/docker.py
@@ -32,6 +32,10 @@ class DockerTerminal(Terminal):
         setup_commands: list[str] | None = None,
         command_timeout: int = 300,
         extra_labels: dict[str, str] | None = None,
+        # Container resource limits
+        mem_limit: str = "16G",
+        pids_limit: int | None = 4096,
+        cpu_limit: float | None = None,
         **kwargs,
     ):
         """
@@ -51,6 +55,12 @@ class DockerTerminal(Terminal):
                         command_timeout: 60
             extra_labels: Additional labels to add to the container (e.g., {"run-id": "my-run"}).
                 Useful for identifying containers during cleanup.
+            mem_limit: Container memory limit (default: "16G"). Uses Docker's memory limit
+                format (e.g., "8G", "32G", "512M").
+            pids_limit: Maximum number of PIDs in the container (default: 4096).
+                Prevents fork bombs and runaway thread creation. Set to None for unlimited.
+            cpu_limit: Maximum number of CPU cores the container can use (e.g., 4.0).
+                Default is None (unlimited). Passed to Docker as nano_cpus.
             **kwargs: Additional arguments (ignored with debug log).
         """
         super().__init__(
@@ -65,6 +75,9 @@ class DockerTerminal(Terminal):
         self.setup_commands = setup_commands or []
         self.command_timeout = command_timeout
         self.extra_labels = extra_labels or {}
+        self.mem_limit = mem_limit
+        self.pids_limit = pids_limit
+        self.cpu_limit = cpu_limit
         self._docker_client = None  # Lazily initialized
         self._container = None
 
@@ -253,7 +266,7 @@ class DockerTerminal(Terminal):
         if self.extra_labels:
             labels.update(self.extra_labels)
 
-        container = self.docker_client.containers.run(
+        container_kwargs = dict(
             name=container_name,
             image=f"{self.registry}{self.base_image}",
             command="sleep infinity",  # Keep the container running
@@ -266,8 +279,14 @@ class DockerTerminal(Terminal):
             tty=True,
             stdin_open=True,
             network_mode="host",
-            mem_limit="16G",
+            mem_limit=self.mem_limit,
         )
+        if self.pids_limit is not None:
+            container_kwargs["pids_limit"] = self.pids_limit
+        if self.cpu_limit is not None:
+            container_kwargs["nano_cpus"] = int(self.cpu_limit * 1e9)
+
+        container = self.docker_client.containers.run(**container_kwargs)
         container.reload()  # Refresh container attributes (e.g., status="running")
         self._run_setup_commands(container)
         self.logger.debug(f"{container} ({container_name}) started successfully.")

--- a/tests/gym/terminals/test_docker.py
+++ b/tests/gym/terminals/test_docker.py
@@ -343,3 +343,127 @@ def test_docker_terminal_nohup_without_redirection_may_timeout(tmp_path):
         terminal.run("pkill -f 'sleep 100'")
     finally:
         terminal.clean_up()
+
+
+@pytest.if_docker_running
+def test_docker_terminal_default_resource_limits():
+    """Test that default resource limits are set correctly."""
+    terminal = DockerTerminal(base_image="ubuntu:latest")
+    try:
+        assert terminal.mem_limit == "16G"
+        assert terminal.pids_limit == 4096
+        assert terminal.cpu_limit is None
+        assert terminal.container.status == "running"
+    finally:
+        terminal.clean_up()
+
+
+@pytest.if_docker_running
+def test_docker_terminal_custom_mem_limit(tmp_path):
+    """Test that custom mem_limit is applied to the container."""
+    working_dir = str(tmp_path)
+    terminal = DockerTerminal(
+        working_dir=working_dir, base_image="ubuntu:latest", mem_limit="512M"
+    )
+    try:
+        assert terminal.mem_limit == "512M"
+        assert terminal.container.status == "running"
+        # Verify the memory limit is applied inside the container via cgroup
+        success, output = terminal.run(
+            "cat /sys/fs/cgroup/memory.max 2>/dev/null || "
+            "cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null",
+            timeout=5,
+        )
+        assert success is True
+        # 512M = 536870912 bytes
+        assert "536870912" in output
+    finally:
+        terminal.clean_up()
+
+
+@pytest.if_docker_running
+def test_docker_terminal_custom_pids_limit(tmp_path):
+    """Test that custom pids_limit is applied to the container."""
+    working_dir = str(tmp_path)
+    terminal = DockerTerminal(
+        working_dir=working_dir, base_image="ubuntu:latest", pids_limit=100
+    )
+    try:
+        assert terminal.pids_limit == 100
+        assert terminal.container.status == "running"
+        # Verify the PID limit via cgroup
+        success, output = terminal.run(
+            "cat /sys/fs/cgroup/pids.max 2>/dev/null || "
+            "cat /sys/fs/cgroup/pids/pids.max 2>/dev/null",
+            timeout=5,
+        )
+        assert success is True
+        assert "100" in output
+    finally:
+        terminal.clean_up()
+
+
+@pytest.if_docker_running
+def test_docker_terminal_pids_limit_none(tmp_path):
+    """Test that pids_limit=None allows unlimited PIDs."""
+    working_dir = str(tmp_path)
+    terminal = DockerTerminal(
+        working_dir=working_dir, base_image="ubuntu:latest", pids_limit=None
+    )
+    try:
+        assert terminal.pids_limit is None
+        assert terminal.container.status == "running"
+        # Container should run fine without PID limit
+        success, output = terminal.run("echo 'no pids limit'", timeout=5)
+        assert success is True
+        assert "no pids limit" in output
+    finally:
+        terminal.clean_up()
+
+
+@pytest.if_docker_running
+def test_docker_terminal_custom_cpu_limit(tmp_path):
+    """Test that custom cpu_limit is applied to the container."""
+    working_dir = str(tmp_path)
+    terminal = DockerTerminal(
+        working_dir=working_dir, base_image="ubuntu:latest", cpu_limit=2.0
+    )
+    try:
+        assert terminal.cpu_limit == 2.0
+        assert terminal.container.status == "running"
+        # Verify CPU quota via cgroup (2 cores = 200000 microseconds per 100000 period)
+        success, output = terminal.run(
+            "cat /sys/fs/cgroup/cpu.max 2>/dev/null || "
+            "cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null",
+            timeout=5,
+        )
+        assert success is True
+        assert "200000" in output
+    finally:
+        terminal.clean_up()
+
+
+@pytest.if_docker_running
+def test_docker_terminal_resource_limits_via_select_terminal():
+    """Test that resource limits can be configured via select_terminal config dict."""
+    config = {
+        "type": "docker",
+        "mem_limit": "1G",
+        "pids_limit": 2048,
+        "cpu_limit": 1.5,
+    }
+    terminal = select_terminal(config)
+    try:
+        assert isinstance(terminal, DockerTerminal)
+        assert terminal.mem_limit == "1G"
+        assert terminal.pids_limit == 2048
+        assert terminal.cpu_limit == 1.5
+        # Verify config dict is not modified
+        assert config == {
+            "type": "docker",
+            "mem_limit": "1G",
+            "pids_limit": 2048,
+            "cpu_limit": 1.5,
+        }
+    finally:
+        terminal.clean_up()


### PR DESCRIPTION
Add mem_limit, pids_limit, and cpu_limit parameters to DockerTerminal so downstream users can control container resource constraints via YAML config.

- mem_limit (default: "16G"): container memory limit, unchanged from previous hardcoded value
- pids_limit (default: 4096): prevents fork bombs and runaway thread creation. Set to None for unlimited (Docker default)
- cpu_limit (default: None/unlimited): max CPU cores, passed as nano_cpus

All parameters are backward compatible. New defaults preserve existing behavior except pids_limit which adds a safe default to prevent fork bomb incidents.

Configurable via YAML:
  terminal:
    type: docker
    mem_limit: "32G"
    pids_limit: 4096
    cpu_limit: 4.0