### PR TITLE
Fix command injection in grep and workspace writes

### DIFF
--- a/debug_gym/gym/tools/grep.py
+++ b/debug_gym/gym/tools/grep.py
@@ -9,6 +9,8 @@ from debug_gym.gym.tools.toolbox import Toolbox
 @Toolbox.register()
 class GrepTool(EnvironmentTool):
     name: str = "grep"
+    DEFAULT_MAX_RESULTS = 100
+    MAX_RESULTS = 10_000
 
     examples = [
         """Use grep with `pattern`: "function" to search for the word "function" in all files in the repository.""",
@@ -34,7 +36,10 @@ class GrepTool(EnvironmentTool):
         },
         "max_results": {
             "type": ["number", "null"],
-            "description": "Maximum number of matching lines to return. If None, returns 100 matches.",
+            "description": (
+                "Maximum number of matching lines to return, from 1 to 10000. "
+                "If None, returns 100 matches."
+            ),
         },
     }
 
@@ -46,11 +51,23 @@ class GrepTool(EnvironmentTool):
         regex: bool = True,
         case_sensitive: bool = True,
         line_numbers: bool = True,
-        max_results: int = 100,
+        max_results: int = DEFAULT_MAX_RESULTS,
     ) -> Observation:
         """Use grep functionality via bash tool as a special case."""
         if not pattern:
             return Observation(self.name, "Pattern cannot be empty.")
+
+        if max_results is None:
+            max_results = self.DEFAULT_MAX_RESULTS
+        if (
+            isinstance(max_results, bool)
+            or not isinstance(max_results, int)
+            or not 1 <= max_results <= self.MAX_RESULTS
+        ):
+            return Observation(
+                self.name,
+                f"max_results must be an integer between 1 and {self.MAX_RESULTS}.",
+            )
 
         # Build grep command arguments
         grep_args = []
@@ -85,8 +102,7 @@ class GrepTool(EnvironmentTool):
             " | grep -v '/.git/' | grep -v '__pycache__' | grep -v '/node_modules/'"
         )
 
-        if max_results:
-            command += f" | head -{max_results}"
+        command += f" | head -{max_results:d}"
 
         try:
             # Use the environment's terminal to run the grep command

--- a/debug_gym/gym/workspace.py
+++ b/debug_gym/gym/workspace.py
@@ -127,58 +127,12 @@ class Workspace:
                 f"Failed to write `{filepath}` because it is outside the workspace."
             )
 
-        def _run_or_raise(command: str):
-            success, output = self.terminal.run(
-                command, raises=False, strip_output=False
-            )
-            if not success:
-                message = output.strip() or "Unknown error"
-                raise WorkspaceWriteError(
-                    f"Failed to write `{filepath}`. Command output:\n{message}"
-                )
-
-        # create parent directories via the terminal if needed
-        _run_or_raise(f"mkdir -p {shlex.quote(str(abs_filepath.parent))}")
-
-        # Use terminal file-copy for large content to avoid slow command-based writes.
-        chunk_size = 32 * 1024  # 32kB
-        if len(content) > chunk_size:
-            relative_filepath = abs_filepath.relative_to(self.working_dir)
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                staged_filepath = Path(tmp_dir) / relative_filepath
-                staged_filepath.parent.mkdir(parents=True, exist_ok=True)
-                staged_filepath.write_text(content, encoding="utf-8")
-                self.terminal.copy_content(tmp_dir, self.working_dir)
-            return
-
-        # Split smaller content in chunks of 32kB to avoid hitting command length limits.
-        first_chunk = content[:chunk_size]
-        rest = content[chunk_size:]
-
-        # In the following command we:
-        # - use a single-quoted heredoc (cat <<'nDEBUGGYM_EOF' ... nDEBUGGYM_EOF) so the heredoc body is taken literally (no shell expansion)
-        # - append a sentinel character DEBUGGYM_DEL inside the heredoc so we can detect/restore trailing newlines later
-        # - capture the heredoc output into shell variable CONTENT since command substitution strips trailing newlines
-        # - "${CONTENT%DEBUGGYM_DEL}" removes the trailing sentinel DEBUGGYM_DEL (restoring the original trailing-newline state)
-        # - echo -n writes the result without adding an extra newline
-        quoted_filepath = shlex.quote(str(abs_filepath))
-        cmd = (
-            "CONTENT=$(cat <<'DEBUGGYM_EOF'\n"
-            f"{first_chunk}DEBUGGYM_DEL\nDEBUGGYM_EOF\n); "
-            'echo -n "${CONTENT%DEBUGGYM_DEL}" > '
-            f"{quoted_filepath}"
-        )
-        _run_or_raise(cmd)
-
-        for i in range(0, len(rest), chunk_size):
-            chunk = rest[i : i + chunk_size]
-            cmd = (
-                "CONTENT=$(cat <<'DEBUGGYM_EOF'\n"
-                f"{chunk}DEBUGGYM_DEL\nDEBUGGYM_EOF\n); "
-                'echo -n "${CONTENT%DEBUGGYM_DEL}" >> '
-                f"{quoted_filepath}"
-            )
-            _run_or_raise(cmd)
+        relative_filepath = abs_filepath.relative_to(self.working_dir)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            staged_filepath = Path(tmp_dir) / relative_filepath
+            staged_filepath.parent.mkdir(parents=True, exist_ok=True)
+            staged_filepath.write_text(content, encoding="utf-8")
+            self.terminal.copy_content(tmp_dir, self.working_dir)
 
     def directory_tree(self, root: str | Path = None, max_depth: int = 1):
         """List the directory tree using the `tree` command.

--- a/tests/gym/test_workspace.py
+++ b/tests/gym/test_workspace.py
@@ -160,6 +160,17 @@ def test_write_file_exceeding_max_command_length(workspace):
     assert workspace.read_file("test.txt") == file_content_exceeding_max_command_length
 
 
+def test_write_file_does_not_execute_content(workspace):
+    side_effect = workspace.working_dir / "side-effect"
+    content = f"payload\nDEBUGGYM_EOF\n); touch {side_effect}\n#"
+
+    workspace.write_file("payload.txt", content)
+
+    assert workspace.read_file("payload.txt") == content
+    success, _ = workspace.terminal.run(f"test ! -e {side_effect}")
+    assert success
+
+
 def test_write_file_path_outside_workspace_relative(workspace):
     """Ensure path traversal attacks are blocked."""
     with pytest.raises(WorkspaceWriteError) as exc_info:

--- a/tests/gym/tools/test_grep.py
+++ b/tests/gym/tools/test_grep.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from debug_gym.gym.tools.grep import GrepTool
@@ -254,6 +256,34 @@ class TestGrepTool:
             "search limit reached" in result.observation
             or "Found 2 matches" in result.observation
         )
+
+    @pytest.mark.parametrize(
+        "max_results",
+        ["10; touch /tmp/grep-injection", "10.5", 0, -1, 10_001, True],
+    )
+    def test_grep_rejects_invalid_max_results_without_running_terminal(
+        self, max_results
+    ):
+        terminal = Mock()
+        environment = Mock(terminal=terminal)
+
+        result = GrepTool().use(environment, pattern="needle", max_results=max_results)
+
+        assert (
+            "max_results must be an integer between 1 and 10000" in result.observation
+        )
+        terminal.run.assert_not_called()
+
+    @pytest.mark.parametrize("max_results", [1, 10_000])
+    def test_grep_accepts_max_results_bounds(self, max_results):
+        terminal = Mock()
+        terminal.run.return_value = (True, "")
+        environment = Mock(terminal=terminal)
+
+        GrepTool().use(environment, pattern="needle", max_results=max_results)
+
+        command = terminal.run.call_args.args[0]
+        assert command.endswith(f" | head -{max_results}")
 
     def test_grep_no_matches_found(self, tmp_path, setup_grep_repo_env):
         """Test behavior when no matches are found"""


### PR DESCRIPTION
## Summary

Fix the two CWE-78 command-injection findings with a minimal, four-file change.

- Validate `GrepTool.max_results` as a bounded integer before interpolating it into the shell pipeline.
- Stage workspace file content in a temporary directory and transfer it through the terminal's existing `copy_content` API, removing heredoc command construction for all payload sizes.
- Add regression tests proving invalid grep limits never reach the terminal and heredoc-shaped file content is written literally without execution.

## Scope

This PR intentionally excludes the unrelated generic tool-parser recovery and advanced filesystem metadata hardening from #371. The CWE-1188 LocalTerminal finding was already resolved by #375, which removed LocalTerminal.

## Validation

- Black
- isort
- Python 3.12 syntax compilation
